### PR TITLE
Support Unique_id

### DIFF
--- a/custom_components/ams/__init__.py
+++ b/custom_components/ams/__init__.py
@@ -11,6 +11,7 @@ from .parsers import aidon as Aidon
 from .const import (
     _LOGGER,
     AMS_DEVICES,
+    AMS_NEW_SENSORS,
     AMS_SENSORS,
     CONF_SERIAL_PORT,
     CONF_PARITY,
@@ -136,6 +137,7 @@ class AmsHub:
         _LOGGER.debug('AMS_DEVICES= %s', AMS_DEVICES)
         if len(AMS_DEVICES) < len(sensor_list):
             new_devices = list(set(sensor_list) ^ set(AMS_DEVICES))
+            self._hass.data[AMS_NEW_SENSORS] = new_devices
             for device in new_devices:
                 AMS_DEVICES.append(device)
             async_dispatcher_send(self._hass, SIGNAL_NEW_AMS_SENSOR)

--- a/custom_components/ams/const.py
+++ b/custom_components/ams/const.py
@@ -4,6 +4,7 @@ import serial
 
 _LOGGER = logging.getLogger(__name__)
 
+AMS_NEW_SENSORS = 'ams_new_sensors'
 AMS_SENSORS = 'ams_sensors'
 AMS_DEVICES = []
 

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -62,8 +62,8 @@ def parse_data(stored, data):
                                       ["meter_serial"],
                 'unit_of_measurement': 'W',
                 'icon': 'mdi:gauge',
-                'unique_id': f'ams_active_power_import_'
-                             '{han_data["meter_serial"]}'
+                'unique_id': (f'ams_active_power_import_'
+                              '{han_data["meter_serial"]}')
             }
         }
         return sensor_data
@@ -83,8 +83,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'W',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_import_'
-                         '{han_data["meter_serial"]}'
+            'unique_id': (f'ams_active_power_import_'
+                          '{han_data["meter_serial"]}')
             }
         }
     han_data["obis_a_p_n"] = field_type(".", fields=pkt[112:118])
@@ -112,8 +112,8 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_import_'
-                         '{han_data["meter_serial"]}'
+            'unique_id': (f'ams_reactive_power_import_'
+                          '{han_data["meter_serial"]}')
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[154:160])
@@ -127,8 +127,8 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_export_'
-                         '{han_data["meter_serial"]}'
+            'unique_id': (f'ams_reactive_power_export_'
+                          '{han_data["meter_serial"]}')
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[175:181])
@@ -234,8 +234,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_import_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[315:321])
@@ -252,8 +252,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_export_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[336:342])
@@ -269,8 +269,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_import_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[357:363])
@@ -287,8 +287,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_export_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
 
@@ -393,8 +393,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_import_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[334:340])
@@ -411,8 +411,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_export_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[355:361])
@@ -428,8 +428,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_import_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[376:3382])
@@ -446,8 +446,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_export_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
 
@@ -496,8 +496,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_import_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[258:264])
@@ -514,8 +514,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_export_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[279:285])
@@ -532,8 +532,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVAh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_import_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[300:306])
@@ -550,8 +550,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVAh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_export_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
 

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -62,7 +62,7 @@ def parse_data(stored, data):
                                       ["meter_serial"],
                 'unit_of_measurement': 'W',
                 'icon': 'mdi:gauge',
-                'unique_id': f'ams_active_power_import-'
+                'unique_id': f'ams_active_power_import_'
                              '{han_data["meter_serial"]}'
             }
         }
@@ -83,7 +83,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'W',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_import-'
+            'unique_id': f'ams_active_power_import_'
                          '{han_data["meter_serial"]}'
             }
         }
@@ -98,7 +98,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_a_p_n"],
             'unit_of_measurement': 'W',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_export-{han_data["meter_serial"]}'
+            'unique_id': f'ams_active_power_export_{han_data["meter_serial"]}'
             }
         }
     han_data["obis_r_p_p"] = field_type(".", fields=pkt[133:139])
@@ -112,7 +112,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_import-'
+            'unique_id': f'ams_reactive_power_import_'
                          '{han_data["meter_serial"]}'
             }
         }
@@ -127,7 +127,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_export-'
+            'unique_id': f'ams_reactive_power_export_'
                          '{han_data["meter_serial"]}'
             }
         }
@@ -142,7 +142,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_c_l1"],
             'unit_of_measurement': 'A',
             'icon': 'mdi:current-ac',
-            'unique_id': f'ams_current_l1-{han_data["meter_serial"]}'
+            'unique_id': f'ams_current_l1_{han_data["meter_serial"]}'
             }
         }
 
@@ -160,7 +160,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
                 'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l3-{han_data["meter_serial"]}'
+                'unique_id': f'ams_current_l3_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[213:219])
@@ -174,7 +174,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
 
                 }
             }
@@ -189,7 +189,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l2"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l2-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l2_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[251:257])
@@ -203,7 +203,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l3-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l3_{han_data["meter_serial"]}'
                 }
             }
         if list_type is LIST_TYPE_LONG_3PH_3W:
@@ -234,7 +234,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import-'
+                    'unique_id': f'ams_active_energy_import_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -252,7 +252,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export-'
+                    'unique_id': f'ams_active_energy_export_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -269,7 +269,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import-'
+                    'unique_id': f'ams_reactive_energy_import_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -287,7 +287,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export-'
+                    'unique_id': f'ams_reactive_energy_export_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -306,7 +306,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_c_l2"],
                 'unit_of_measurement': 'A',
                 'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l2-{han_data["meter_serial"]}'
+                'unique_id': f'ams_current_l2_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_c_l3"] = field_type(".", fields=pkt[213:219])
@@ -320,7 +320,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
                 'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l3-{han_data["meter_serial"]}'
+                'unique_id': f'ams_current_l3_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[232:238])
@@ -333,7 +333,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[251:257])
@@ -346,7 +347,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l2"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l2_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[270:276])
@@ -360,7 +362,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l3-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l3_{han_data["meter_serial"]}'
                 }
             }
         if list_type is LIST_TYPE_LONG_3PH_3W:
@@ -391,7 +393,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import-'
+                    'unique_id': f'ams_active_energy_import_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -409,7 +411,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export-'
+                    'unique_id': f'ams_active_energy_export_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -426,7 +428,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import-'
+                    'unique_id': f'ams_reactive_energy_import_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -444,7 +446,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export-'
+                    'unique_id': f'ams_reactive_energy_export_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -462,7 +464,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
                 }
             }
 
@@ -494,7 +496,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import-'
+                    'unique_id': f'ams_active_energy_import_'
                                  '{han_data["meter_serial"]}'
                     }
                 }
@@ -512,7 +514,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export-'
+                    'unique_id': f'ams_active_energy_export_'
                                  '{han_data["meter_serial"]}'
                     }
                 }
@@ -530,7 +532,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVAh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import-'
+                    'unique_id': f'ams_reactive_energy_import_'
                                  '{han_data["meter_serial"]}'
                     }
                 }
@@ -548,7 +550,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVAh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export-'
+                    'unique_id': f'ams_reactive_energy_export_'
                                  '{han_data["meter_serial"]}'
                     }
                 }

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -63,7 +63,7 @@ def parse_data(stored, data):
                 'unit_of_measurement': 'W',
                 'icon': 'mdi:gauge',
                 'unique_id': (f'ams_active_power_import_'
-                              '{han_data["meter_serial"]}')
+                              f'{han_data["meter_serial"]}')
             }
         }
         return sensor_data
@@ -84,7 +84,7 @@ def parse_data(stored, data):
             'unit_of_measurement': 'W',
             'icon': 'mdi:gauge',
             'unique_id': (f'ams_active_power_import_'
-                          '{han_data["meter_serial"]}')
+                          f'{han_data["meter_serial"]}')
             }
         }
     han_data["obis_a_p_n"] = field_type(".", fields=pkt[112:118])
@@ -113,7 +113,7 @@ def parse_data(stored, data):
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
             'unique_id': (f'ams_reactive_power_import_'
-                          '{han_data["meter_serial"]}')
+                          f'{han_data["meter_serial"]}')
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[154:160])
@@ -128,7 +128,7 @@ def parse_data(stored, data):
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
             'unique_id': (f'ams_reactive_power_export_'
-                          '{han_data["meter_serial"]}')
+                          f'{han_data["meter_serial"]}')
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[175:181])
@@ -235,7 +235,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[315:321])
@@ -253,7 +253,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[336:342])
@@ -270,7 +270,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[357:363])
@@ -288,7 +288,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
 
@@ -394,7 +394,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[334:340])
@@ -412,7 +412,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[355:361])
@@ -429,7 +429,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[376:3382])
@@ -447,7 +447,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
 
@@ -497,7 +497,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[258:264])
@@ -515,7 +515,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[279:285])
@@ -533,7 +533,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVAh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[300:306])
@@ -551,7 +551,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVAh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
 

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -50,12 +50,20 @@ def parse_data(stored, data):
         sensor_data["ams_active_power_import"] = {
             'state': han_data["active_power_p"],
             'attributes': {
-                'meter_manufacturer': stored["ams_active_power_import"]["attributes"]["meter_manufacturer"],
+                'meter_manufacturer': (stored["ams_active_power_import"]
+                                       ["attributes"]
+                                       ["meter_manufacturer"]),
                 'obis_code': han_data["obis_a_p_p"],
-                'meter_type': stored["ams_active_power_import"]["attributes"]["meter_type"],
-                'meter_serial': stored["ams_active_power_import"]["attributes"]["meter_serial"],
+                'meter_type': (stored["ams_active_power_import"]
+                               ["attributes"]
+                               ["meter_type"]),
+                'meter_serial': stored["ams_active_power_import"]
+                                      ["attributes"]
+                                      ["meter_serial"],
                 'unit_of_measurement': 'W',
-                'icon': 'mdi:gauge'
+                'icon': 'mdi:gauge',
+                'unique_id': f'ams_active_power_import-'
+                             '{han_data["meter_serial"]}'
             }
         }
         return sensor_data
@@ -74,7 +82,9 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_active_power_import-'
+                         '{han_data["meter_serial"]}'
             }
         }
     han_data["obis_a_p_n"] = field_type(".", fields=pkt[112:118])
@@ -87,7 +97,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_a_p_n"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_active_power_export-{han_data["meter_serial"]}'
             }
         }
     han_data["obis_r_p_p"] = field_type(".", fields=pkt[133:139])
@@ -100,7 +111,9 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_reactive_power_import-'
+                         '{han_data["meter_serial"]}'
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[154:160])
@@ -113,7 +126,9 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_reactive_power_export-'
+                         '{han_data["meter_serial"]}'
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[175:181])
@@ -126,7 +141,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_c_l1"],
             'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac'
+            'icon': 'mdi:current-ac',
+            'unique_id': f'ams_current_l1-{han_data["meter_serial"]}'
             }
         }
 
@@ -143,7 +159,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
+                'icon': 'mdi:current-ac',
+                'unique_id': f'ams_current_l3-{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[213:219])
@@ -156,7 +173,9 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
+
                 }
             }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[232:238])
@@ -169,7 +188,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l2"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l2-{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[251:257])
@@ -182,7 +202,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l3-{han_data["meter_serial"]}'
                 }
             }
         if list_type is LIST_TYPE_LONG_3PH_3W:
@@ -212,7 +233,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_import-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[315:321])
@@ -228,7 +251,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_export-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[336:342])
@@ -243,7 +268,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_import-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[357:363])
@@ -259,7 +286,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_export-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
 
@@ -276,7 +305,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l2"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
+                'icon': 'mdi:current-ac',
+                'unique_id': f'ams_current_l2-{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_c_l3"] = field_type(".", fields=pkt[213:219])
@@ -289,7 +319,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
+                'icon': 'mdi:current-ac',
+                'unique_id': f'ams_current_l3-{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[232:238])
@@ -328,7 +359,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l3-{han_data["meter_serial"]}'
                 }
             }
         if list_type is LIST_TYPE_LONG_3PH_3W:
@@ -358,7 +390,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_import-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[334:340])
@@ -374,7 +408,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_export-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[355:361])
@@ -389,7 +425,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_import-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[376:3382])
@@ -405,7 +443,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_export-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
 
@@ -421,7 +461,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
                 }
             }
 
@@ -452,7 +493,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_import-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[258:264])
@@ -468,7 +511,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_export-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[279:285])
@@ -484,7 +529,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVAh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_import-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[300:306])
@@ -500,7 +547,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVAh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_export-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
 

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -61,9 +61,7 @@ def parse_data(stored, data):
                                       ["attributes"]
                                       ["meter_serial"],
                 'unit_of_measurement': 'W',
-                'icon': 'mdi:gauge',
-                'unique_id': (f'ams_active_power_import_'
-                              f'{han_data["meter_serial"]}')
+                'icon': 'mdi:gauge'
             }
         }
         return sensor_data
@@ -82,9 +80,7 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge',
-            'unique_id': (f'ams_active_power_import_'
-                          f'{han_data["meter_serial"]}')
+            'icon': 'mdi:gauge'
             }
         }
     han_data["obis_a_p_n"] = field_type(".", fields=pkt[112:118])
@@ -97,8 +93,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_a_p_n"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_export_{han_data["meter_serial"]}'
+            'icon': 'mdi:gauge'
             }
         }
     han_data["obis_r_p_p"] = field_type(".", fields=pkt[133:139])
@@ -111,9 +106,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge',
-            'unique_id': (f'ams_reactive_power_import_'
-                          f'{han_data["meter_serial"]}')
+            'icon': 'mdi:gauge'
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[154:160])
@@ -126,9 +119,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge',
-            'unique_id': (f'ams_reactive_power_export_'
-                          f'{han_data["meter_serial"]}')
+            'icon': 'mdi:gauge'
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[175:181])
@@ -141,8 +132,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_c_l1"],
             'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac',
-            'unique_id': f'ams_current_l1_{han_data["meter_serial"]}'
+            'icon': 'mdi:current-ac'
             }
         }
 
@@ -159,8 +149,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l3_{han_data["meter_serial"]}'
+                'icon': 'mdi:current-ac'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[213:219])
@@ -173,9 +162,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
-
+                'icon': 'mdi:flash'
                 }
             }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[232:238])
@@ -188,8 +175,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l2"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l2_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[251:257])
@@ -202,8 +188,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l3_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         if list_type is LIST_TYPE_LONG_3PH_3W:
@@ -233,9 +218,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[315:321])
@@ -251,9 +234,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[336:342])
@@ -268,9 +249,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[357:363])
@@ -286,9 +265,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
 
@@ -305,8 +282,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l2"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l2_{han_data["meter_serial"]}'
+                'icon': 'mdi:current-ac'
                 }
             }
         han_data["obis_c_l3"] = field_type(".", fields=pkt[213:219])
@@ -319,8 +295,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l3_{han_data["meter_serial"]}'
+                'icon': 'mdi:current-ac'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[232:238])
@@ -333,8 +308,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[251:257])
@@ -347,8 +321,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l2"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l2_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[270:276])
@@ -361,8 +334,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l3_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         if list_type is LIST_TYPE_LONG_3PH_3W:
@@ -392,9 +364,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[334:340])
@@ -410,9 +380,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[355:361])
@@ -427,9 +395,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[376:3382])
@@ -445,9 +411,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
 
@@ -463,8 +427,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
 
@@ -495,9 +458,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[258:264])
@@ -513,9 +474,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[279:285])
@@ -531,9 +490,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVAh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[300:306])
@@ -549,9 +506,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVAh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
 

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -58,7 +58,9 @@ def parse_data(stored, data):
             'attributes': {
                 'timestamp': han_data["date_time"],
                 'unit_of_measurement': 'W',
-                'icon': 'mdi:gauge'
+                'icon': 'mdi:gauge',
+                'unique_id': f'ams_active_power_import-'
+                             '{han_data["meter_serial"]}'
             }
         }
         return sensor_data
@@ -77,7 +79,8 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_active_power_export-{han_data["meter_serial"]}'
             }
         }
     han_data["reactive_power_p"] = byte_decode(fields=pkt[81:85])
@@ -89,7 +92,9 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_reactive_power_import-'
+                         '{han_data["meter_serial"]}'
             }
         }
     han_data["reactive_power_n"] = byte_decode(fields=pkt[86:90])
@@ -101,7 +106,9 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_reactive_power_export-'
+                         '{han_data["meter_serial"]}'
             }
         }
     han_data["current_l1"] = byte_decode(fields=pkt[91:95]) / 1000
@@ -113,7 +120,8 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac'
+            'icon': 'mdi:current-ac',
+            'unique_id': f'ams_current_l1-{han_data["meter_serial"]}'
             }
         }
 
@@ -128,7 +136,8 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
+                'icon': 'mdi:current-ac',
+                'unique_id': f'ams_current_l2-{han_data["meter_serial"]}'
                 }
             }
         han_data["current_l3"] = byte_decode(fields=pkt[101:105]) / 1000
@@ -140,7 +149,8 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
+                'icon': 'mdi:current-ac',
+                'unique_id': f'ams_current_l3-{han_data["meter_serial"]}'
                 }
             }
         han_data["voltage_l1"] = byte_decode(fields=pkt[106:110]) / 10
@@ -152,7 +162,8 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
                 }
             }
         han_data["voltage_l2"] = byte_decode(fields=pkt[111:115]) / 10
@@ -164,7 +175,8 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l2-{han_data["meter_serial"]}'
                 }
             }
         han_data["voltage_l3"] = byte_decode(fields=pkt[116:120]) / 10
@@ -176,7 +188,8 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l3-{han_data["meter_serial"]}'
                 }
             }
         if list_type == LIST_TYPE_LONG_3PH:
@@ -205,7 +218,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_import-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["active_energy_n"] = byte_decode(
@@ -220,7 +235,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_export-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["reactive_energy_p"] = byte_decode(
@@ -235,7 +252,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_import-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["reactive_energy_n"] = byte_decode(
@@ -250,7 +269,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_export-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
 
@@ -266,7 +287,8 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
                 }
             }
 
@@ -296,7 +318,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_import-'
+                        '{han_data["meter_serial"]}'
                     }
                 }
             han_data["active_energy_n"] = byte_decode(
@@ -311,7 +335,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_export-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
             han_data["reactive_energy_p"] = byte_decode(
@@ -326,7 +352,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_import-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
             han_data["reactive_energy_n"] = byte_decode(
@@ -341,7 +369,9 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_export-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
     return sensor_data

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -69,8 +69,8 @@ def parse_data(stored, data):
                 'timestamp': han_data["date_time"],
                 'unit_of_measurement': 'W',
                 'icon': 'mdi:gauge',
-                'unique_id': f'ams_active_power_import_'
-                             '{han_data["meter_serial"]}'
+                'unique_id': (f'ams_active_power_import_'
+                              '{han_data["meter_serial"]}')
             }
         }
         return sensor_data
@@ -103,8 +103,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_import-'
-                         '{han_data["meter_serial"]}'
+            'unique_id': (f'ams_reactive_power_import-'
+                          '{han_data["meter_serial"]}')
             }
         }
     han_data["reactive_power_n"] = byte_decode(fields=pkt[86:90])
@@ -117,8 +117,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_export_'
-                         '{han_data["meter_serial"]}'
+            'unique_id': (f'ams_reactive_power_export_'
+                          '{han_data["meter_serial"]}')
             }
         }
     han_data["current_l1"] = byte_decode(fields=pkt[91:95]) / 1000
@@ -229,8 +229,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_import_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["active_energy_n"] = byte_decode(
@@ -246,8 +246,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_export_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["reactive_energy_p"] = byte_decode(
@@ -263,8 +263,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_import_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["reactive_energy_n"] = byte_decode(
@@ -280,8 +280,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_export_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
 
@@ -329,8 +329,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import_'
-                        '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_import_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["active_energy_n"] = byte_decode(
@@ -346,8 +346,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_export_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["reactive_energy_p"] = byte_decode(
@@ -363,8 +363,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_import_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["reactive_energy_n"] = byte_decode(
@@ -380,8 +380,8 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_export_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
     return sensor_data

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -31,7 +31,7 @@ METER_TYPE = {
 def parse_data(stored, data):
     """Parse the incoming data to dict."""
     sensor_data = {}
-    han_data = stored
+    han_data = {}
     pkt = data
     read_packet_size = ((data[1] & 0x0F) << 8 | data[2]) + 2
     han_data["packet_size"] = read_packet_size
@@ -52,10 +52,20 @@ def parse_data(stored, data):
     list_type = pkt[32]
     han_data["list_type"] = list_type
     if list_type is LIST_TYPE_MINI:
+        if "ams_active_power_import" not in stored:
+            # Wait for long message to get full attribute set before
+            # publishing mini list data
+            return stored
         han_data["active_power_p"] = byte_decode(fields=pkt[34:38])
         sensor_data["ams_active_power_import"] = {
             'state': han_data["active_power_p"],
             'attributes': {
+                'meter_manufacturer': (stored["ams_active_power_import"]
+                                       ["attributes"]["meter_manufacturer"])
+                'meter_type': (stored["ams_active_power_import"]
+                               ["attributes"]["meter_type"])
+                'meter_serial': (stored["ams_active_power_import"]
+                                 ["attributes"]["meter_serial"])
                 'timestamp': han_data["date_time"],
                 'unit_of_measurement': 'W',
                 'icon': 'mdi:gauge',

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -61,11 +61,11 @@ def parse_data(stored, data):
             'state': han_data["active_power_p"],
             'attributes': {
                 'meter_manufacturer': (stored["ams_active_power_import"]
-                                       ["attributes"]["meter_manufacturer"])
+                                       ["attributes"]["meter_manufacturer"]),
                 'meter_type': (stored["ams_active_power_import"]
-                               ["attributes"]["meter_type"])
+                               ["attributes"]["meter_type"]),
                 'meter_serial': (stored["ams_active_power_import"]
-                                 ["attributes"]["meter_serial"])
+                                 ["attributes"]["meter_serial"]),
                 'timestamp': han_data["date_time"],
                 'unit_of_measurement': 'W',
                 'icon': 'mdi:gauge',

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -69,7 +69,7 @@ def parse_data(stored, data):
                 'timestamp': han_data["date_time"],
                 'unit_of_measurement': 'W',
                 'icon': 'mdi:gauge',
-                'unique_id': f'ams_active_power_import-'
+                'unique_id': f'ams_active_power_import_'
                              '{han_data["meter_serial"]}'
             }
         }
@@ -90,7 +90,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'W',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_export-{han_data["meter_serial"]}'
+            'unique_id': f'ams_active_power_export_{han_data["meter_serial"]}'
             }
         }
     han_data["reactive_power_p"] = byte_decode(fields=pkt[81:85])
@@ -117,7 +117,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_export-'
+            'unique_id': f'ams_reactive_power_export_'
                          '{han_data["meter_serial"]}'
             }
         }
@@ -131,7 +131,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'A',
             'icon': 'mdi:current-ac',
-            'unique_id': f'ams_current_l1-{han_data["meter_serial"]}'
+            'unique_id': f'ams_current_l1_{han_data["meter_serial"]}'
             }
         }
 
@@ -147,7 +147,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'A',
                 'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l2-{han_data["meter_serial"]}'
+                'unique_id': f'ams_current_l2_{han_data["meter_serial"]}'
                 }
             }
         han_data["current_l3"] = byte_decode(fields=pkt[101:105]) / 1000
@@ -160,7 +160,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'A',
                 'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l3-{han_data["meter_serial"]}'
+                'unique_id': f'ams_current_l3_{han_data["meter_serial"]}'
                 }
             }
         han_data["voltage_l1"] = byte_decode(fields=pkt[106:110]) / 10
@@ -173,7 +173,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
                 }
             }
         han_data["voltage_l2"] = byte_decode(fields=pkt[111:115]) / 10
@@ -186,7 +186,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l2-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l2_{han_data["meter_serial"]}'
                 }
             }
         han_data["voltage_l3"] = byte_decode(fields=pkt[116:120]) / 10
@@ -199,7 +199,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l3-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l3_{han_data["meter_serial"]}'
                 }
             }
         if list_type == LIST_TYPE_LONG_3PH:
@@ -229,7 +229,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import-'
+                    'unique_id': f'ams_active_energy_import_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -246,7 +246,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export-'
+                    'unique_id': f'ams_active_energy_export_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -263,7 +263,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import-'
+                    'unique_id': f'ams_reactive_energy_import_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -280,7 +280,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export-'
+                    'unique_id': f'ams_reactive_energy_export_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -298,7 +298,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
                 }
             }
 
@@ -329,7 +329,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import-'
+                    'unique_id': f'ams_active_energy_import_'
                         '{han_data["meter_serial"]}'
                     }
                 }
@@ -346,7 +346,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export-'
+                    'unique_id': f'ams_active_energy_export_'
                                  '{han_data["meter_serial"]}'
                     }
                 }
@@ -363,7 +363,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import-'
+                    'unique_id': f'ams_reactive_energy_import_'
                                  '{han_data["meter_serial"]}'
                     }
                 }
@@ -380,7 +380,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export-'
+                    'unique_id': f'ams_reactive_energy_export_'
                                  '{han_data["meter_serial"]}'
                     }
                 }

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -70,7 +70,7 @@ def parse_data(stored, data):
                 'unit_of_measurement': 'W',
                 'icon': 'mdi:gauge',
                 'unique_id': (f'ams_active_power_import_'
-                              '{han_data["meter_serial"]}')
+                              f'{han_data["meter_serial"]}')
             }
         }
         return sensor_data
@@ -104,7 +104,7 @@ def parse_data(stored, data):
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
             'unique_id': (f'ams_reactive_power_import-'
-                          '{han_data["meter_serial"]}')
+                          f'{han_data["meter_serial"]}')
             }
         }
     han_data["reactive_power_n"] = byte_decode(fields=pkt[86:90])
@@ -118,7 +118,7 @@ def parse_data(stored, data):
             'unit_of_measurement': 'VAr',
             'icon': 'mdi:gauge',
             'unique_id': (f'ams_reactive_power_export_'
-                          '{han_data["meter_serial"]}')
+                          f'{han_data["meter_serial"]}')
             }
         }
     han_data["current_l1"] = byte_decode(fields=pkt[91:95]) / 1000
@@ -230,7 +230,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["active_energy_n"] = byte_decode(
@@ -247,7 +247,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["reactive_energy_p"] = byte_decode(
@@ -264,7 +264,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["reactive_energy_n"] = byte_decode(
@@ -281,7 +281,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
 
@@ -330,7 +330,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["active_energy_n"] = byte_decode(
@@ -347,7 +347,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["reactive_energy_p"] = byte_decode(
@@ -364,7 +364,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["reactive_energy_n"] = byte_decode(
@@ -381,7 +381,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
     return sensor_data

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -68,9 +68,7 @@ def parse_data(stored, data):
                                  ["attributes"]["meter_serial"]),
                 'timestamp': han_data["date_time"],
                 'unit_of_measurement': 'W',
-                'icon': 'mdi:gauge',
-                'unique_id': (f'ams_active_power_import_'
-                              f'{han_data["meter_serial"]}')
+                'icon': 'mdi:gauge'
             }
         }
         return sensor_data
@@ -89,8 +87,7 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_export_{han_data["meter_serial"]}'
+            'icon': 'mdi:gauge'
             }
         }
     han_data["reactive_power_p"] = byte_decode(fields=pkt[81:85])
@@ -102,9 +99,7 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge',
-            'unique_id': (f'ams_reactive_power_import-'
-                          f'{han_data["meter_serial"]}')
+            'icon': 'mdi:gauge'
             }
         }
     han_data["reactive_power_n"] = byte_decode(fields=pkt[86:90])
@@ -116,9 +111,7 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge',
-            'unique_id': (f'ams_reactive_power_export_'
-                          f'{han_data["meter_serial"]}')
+            'icon': 'mdi:gauge'
             }
         }
     han_data["current_l1"] = byte_decode(fields=pkt[91:95]) / 1000
@@ -130,8 +123,7 @@ def parse_data(stored, data):
             'meter_type': han_data["meter_type_str"],
             'meter_serial': han_data["meter_serial"],
             'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac',
-            'unique_id': f'ams_current_l1_{han_data["meter_serial"]}'
+            'icon': 'mdi:current-ac'
             }
         }
 
@@ -146,8 +138,7 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l2_{han_data["meter_serial"]}'
+                'icon': 'mdi:current-ac'
                 }
             }
         han_data["current_l3"] = byte_decode(fields=pkt[101:105]) / 1000
@@ -159,8 +150,7 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l3_{han_data["meter_serial"]}'
+                'icon': 'mdi:current-ac'
                 }
             }
         han_data["voltage_l1"] = byte_decode(fields=pkt[106:110]) / 10
@@ -172,8 +162,7 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         han_data["voltage_l2"] = byte_decode(fields=pkt[111:115]) / 10
@@ -185,8 +174,7 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l2_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         han_data["voltage_l3"] = byte_decode(fields=pkt[116:120]) / 10
@@ -198,8 +186,7 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l3_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         if list_type == LIST_TYPE_LONG_3PH:
@@ -228,9 +215,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["active_energy_n"] = byte_decode(
@@ -245,9 +230,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["reactive_energy_p"] = byte_decode(
@@ -262,9 +245,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["reactive_energy_n"] = byte_decode(
@@ -279,9 +260,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
 
@@ -297,8 +276,7 @@ def parse_data(stored, data):
                 'meter_type': han_data["meter_type_str"],
                 'meter_serial': han_data["meter_serial"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
 
@@ -328,9 +306,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["active_energy_n"] = byte_decode(
@@ -345,9 +321,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["reactive_energy_p"] = byte_decode(
@@ -362,9 +336,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["reactive_energy_n"] = byte_decode(
@@ -379,9 +351,7 @@ def parse_data(stored, data):
                     'meter_type': han_data["meter_type_str"],
                     'meter_serial': han_data["meter_serial"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
     return sensor_data

--- a/custom_components/ams/parsers/kamstrup.py
+++ b/custom_components/ams/parsers/kamstrup.py
@@ -101,8 +101,8 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'kVAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_import_'
-                         '{han_data["meter_serial"]}'
+            'unique_id': (f'ams_reactive_power_import_'
+                          '{han_data["meter_serial"]}')
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[142:148])
@@ -117,8 +117,8 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'kVAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_export_'
-                         '{han_data["meter_serial"]}'
+            'unique_id': (f'ams_reactive_power_export_'
+                          '{han_data["meter_serial"]}')
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[155:161])
@@ -245,8 +245,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_import_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[262:268])
@@ -264,8 +264,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_export_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[275:281])
@@ -283,8 +283,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_import_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[288:294])
@@ -302,8 +302,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_export_'
+                                  '{han_data["meter_serial"]}')
                 }
             }
 
@@ -357,8 +357,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_import_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[214:220])
@@ -376,8 +376,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_active_energy_export_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[227:233])
@@ -395,8 +395,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_import_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[240:246])
@@ -414,8 +414,8 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export_'
-                                 '{han_data["meter_serial"]}'
+                    'unique_id': (f'ams_reactive_energy_export_'
+                                  '{han_data["meter_serial"]}')
                     }
                 }
     return sensor_data

--- a/custom_components/ams/parsers/kamstrup.py
+++ b/custom_components/ams/parsers/kamstrup.py
@@ -101,7 +101,8 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'kVAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_import_{han_data["meter_serial"]}'
+            'unique_id': f'ams_reactive_power_import_'
+                         '{han_data["meter_serial"]}'
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[142:148])
@@ -116,7 +117,8 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'kVAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_reactive_power_export_{han_data["meter_serial"]}'
+            'unique_id': f'ams_reactive_power_export_'
+                         '{han_data["meter_serial"]}'
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[155:161])

--- a/custom_components/ams/parsers/kamstrup.py
+++ b/custom_components/ams/parsers/kamstrup.py
@@ -102,7 +102,7 @@ def parse_data(stored, data):
             'unit_of_measurement': 'kVAr',
             'icon': 'mdi:gauge',
             'unique_id': (f'ams_reactive_power_import_'
-                          '{han_data["meter_serial"]}')
+                          f'{han_data["meter_serial"]}')
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[142:148])
@@ -118,7 +118,7 @@ def parse_data(stored, data):
             'unit_of_measurement': 'kVAr',
             'icon': 'mdi:gauge',
             'unique_id': (f'ams_reactive_power_export_'
-                          '{han_data["meter_serial"]}')
+                          f'{han_data["meter_serial"]}')
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[155:161])
@@ -246,7 +246,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[262:268])
@@ -265,7 +265,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[275:281])
@@ -284,7 +284,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[288:294])
@@ -303,7 +303,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                 }
             }
 
@@ -358,7 +358,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[214:220])
@@ -377,7 +377,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_active_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[227:233])
@@ -396,7 +396,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_import_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[240:246])
@@ -415,7 +415,7 @@ def parse_data(stored, data):
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
                     'unique_id': (f'ams_reactive_energy_export_'
-                                  '{han_data["meter_serial"]}')
+                                  f'{han_data["meter_serial"]}')
                     }
                 }
     return sensor_data

--- a/custom_components/ams/parsers/kamstrup.py
+++ b/custom_components/ams/parsers/kamstrup.py
@@ -69,7 +69,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_a_p_p"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_active_power_import-{han_data["meter_serial"]}'
             }
         }
 
@@ -84,7 +85,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_a_p_n"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_active_power_export-{han_data["meter_serial"]}'
             }
         }
     han_data["obis_r_p_p"] = field_type(".", fields=pkt[129:135])
@@ -98,7 +100,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'kVAr',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_ractive_power_import-{han_data["meter_serial"]}'
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[142:148])
@@ -112,7 +115,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'kVAr',
-            'icon': 'mdi:gauge'
+            'icon': 'mdi:gauge',
+            'unique_id': f'ams_ractive_power_export-{han_data["meter_serial"]}'
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[155:161])
@@ -126,7 +130,8 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_c_l1"],
             'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac'
+            'icon': 'mdi:current-ac',
+            'unique_id': f'ams_current_l1-{han_data["meter_serial"]}'
             }
         }
 
@@ -143,7 +148,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l2"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
+                'icon': 'mdi:current-ac',
+                'unique_id': f'ams_current_l2-{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_c_l3"] = field_type(".", fields=pkt[181:187])
@@ -157,7 +163,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
+                'icon': 'mdi:current-ac',
+                'unique_id': f'ams_current_l3-{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[194:200])
@@ -171,7 +178,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[205:211])
@@ -185,7 +193,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l2"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l2-{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[216:222])
@@ -199,7 +208,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l3-{han_data["meter_serial"]}'
                 }
             }
         if list_type == LIST_TYPE_LONG_3PH:
@@ -232,7 +242,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_import-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[262:268])
@@ -249,7 +261,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_export-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[275:281])
@@ -266,7 +280,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_import-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[288:294])
@@ -283,7 +299,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_export-'
+                                 '{han_data["meter_serial"]}'
                 }
             }
 
@@ -301,7 +319,8 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
+                'icon': 'mdi:flash',
+                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
                 }
             }
 
@@ -335,7 +354,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_import-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[214:220])
@@ -352,7 +373,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_active_energy_export-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[227:233])
@@ -369,7 +392,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_reactive_energy_import-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[240:246])
@@ -386,7 +411,9 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
+                    'icon': 'mdi:gauge',
+                    'unique_id': f'ams_rective_energy_export-'
+                                 '{han_data["meter_serial"]}'
                     }
                 }
     return sensor_data

--- a/custom_components/ams/parsers/kamstrup.py
+++ b/custom_components/ams/parsers/kamstrup.py
@@ -70,7 +70,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_a_p_p"],
             'unit_of_measurement': 'W',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_import-{han_data["meter_serial"]}'
+            'unique_id': f'ams_active_power_import_{han_data["meter_serial"]}'
             }
         }
 
@@ -86,7 +86,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_a_p_n"],
             'unit_of_measurement': 'W',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_export-{han_data["meter_serial"]}'
+            'unique_id': f'ams_active_power_export_{han_data["meter_serial"]}'
             }
         }
     han_data["obis_r_p_p"] = field_type(".", fields=pkt[129:135])
@@ -101,7 +101,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'kVAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_ractive_power_import-{han_data["meter_serial"]}'
+            'unique_id': f'ams_reactive_power_import_{han_data["meter_serial"]}'
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[142:148])
@@ -116,7 +116,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'kVAr',
             'icon': 'mdi:gauge',
-            'unique_id': f'ams_ractive_power_export-{han_data["meter_serial"]}'
+            'unique_id': f'ams_reactive_power_export_{han_data["meter_serial"]}'
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[155:161])
@@ -131,7 +131,7 @@ def parse_data(stored, data):
             'obis_code': han_data["obis_c_l1"],
             'unit_of_measurement': 'A',
             'icon': 'mdi:current-ac',
-            'unique_id': f'ams_current_l1-{han_data["meter_serial"]}'
+            'unique_id': f'ams_current_l1_{han_data["meter_serial"]}'
             }
         }
 
@@ -149,7 +149,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_c_l2"],
                 'unit_of_measurement': 'A',
                 'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l2-{han_data["meter_serial"]}'
+                'unique_id': f'ams_current_l2_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_c_l3"] = field_type(".", fields=pkt[181:187])
@@ -164,7 +164,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
                 'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l3-{han_data["meter_serial"]}'
+                'unique_id': f'ams_current_l3_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[194:200])
@@ -179,7 +179,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[205:211])
@@ -194,7 +194,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l2"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l2-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l2_{han_data["meter_serial"]}'
                 }
             }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[216:222])
@@ -209,7 +209,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l3-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l3_{han_data["meter_serial"]}'
                 }
             }
         if list_type == LIST_TYPE_LONG_3PH:
@@ -243,7 +243,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import-'
+                    'unique_id': f'ams_active_energy_import_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -262,7 +262,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export-'
+                    'unique_id': f'ams_active_energy_export_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -281,7 +281,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import-'
+                    'unique_id': f'ams_reactive_energy_import_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -300,7 +300,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_export-'
+                    'unique_id': f'ams_reactive_energy_export_'
                                  '{han_data["meter_serial"]}'
                 }
             }
@@ -320,7 +320,7 @@ def parse_data(stored, data):
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
                 'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1-{han_data["meter_serial"]}'
+                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
                 }
             }
 
@@ -355,7 +355,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_import-'
+                    'unique_id': f'ams_active_energy_import_'
                                  '{han_data["meter_serial"]}'
                     }
                 }
@@ -374,7 +374,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_active_energy_export-'
+                    'unique_id': f'ams_active_energy_export_'
                                  '{han_data["meter_serial"]}'
                     }
                 }
@@ -393,7 +393,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_reactive_energy_import-'
+                    'unique_id': f'ams_reactive_energy_import_'
                                  '{han_data["meter_serial"]}'
                     }
                 }
@@ -412,7 +412,7 @@ def parse_data(stored, data):
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
                     'icon': 'mdi:gauge',
-                    'unique_id': f'ams_rective_energy_export-'
+                    'unique_id': f'ams_reactive_energy_export_'
                                  '{han_data["meter_serial"]}'
                     }
                 }

--- a/custom_components/ams/parsers/kamstrup.py
+++ b/custom_components/ams/parsers/kamstrup.py
@@ -69,8 +69,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_a_p_p"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_import_{han_data["meter_serial"]}'
+            'icon': 'mdi:gauge'
             }
         }
 
@@ -85,8 +84,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_a_p_n"],
             'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge',
-            'unique_id': f'ams_active_power_export_{han_data["meter_serial"]}'
+            'icon': 'mdi:gauge'
             }
         }
     han_data["obis_r_p_p"] = field_type(".", fields=pkt[129:135])
@@ -100,9 +98,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_r_p_p"],
             'unit_of_measurement': 'kVAr',
-            'icon': 'mdi:gauge',
-            'unique_id': (f'ams_reactive_power_import_'
-                          f'{han_data["meter_serial"]}')
+            'icon': 'mdi:gauge'
             }
         }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[142:148])
@@ -116,9 +112,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_r_p_n"],
             'unit_of_measurement': 'kVAr',
-            'icon': 'mdi:gauge',
-            'unique_id': (f'ams_reactive_power_export_'
-                          f'{han_data["meter_serial"]}')
+            'icon': 'mdi:gauge'
             }
         }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[155:161])
@@ -132,8 +126,7 @@ def parse_data(stored, data):
             'meter_serial': han_data["meter_serial"],
             'obis_code': han_data["obis_c_l1"],
             'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac',
-            'unique_id': f'ams_current_l1_{han_data["meter_serial"]}'
+            'icon': 'mdi:current-ac'
             }
         }
 
@@ -150,8 +143,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l2"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l2_{han_data["meter_serial"]}'
+                'icon': 'mdi:current-ac'
                 }
             }
         han_data["obis_c_l3"] = field_type(".", fields=pkt[181:187])
@@ -165,8 +157,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_c_l3"],
                 'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac',
-                'unique_id': f'ams_current_l3_{han_data["meter_serial"]}'
+                'icon': 'mdi:current-ac'
                 }
             }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[194:200])
@@ -180,8 +171,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[205:211])
@@ -195,8 +185,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l2"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l2_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[216:222])
@@ -210,8 +199,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l3"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l3_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
         if list_type == LIST_TYPE_LONG_3PH:
@@ -244,9 +232,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[262:268])
@@ -263,9 +249,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[275:281])
@@ -282,9 +266,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[288:294])
@@ -301,9 +283,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                 }
             }
 
@@ -321,8 +301,7 @@ def parse_data(stored, data):
                 'meter_serial': han_data["meter_serial"],
                 'obis_code': han_data["obis_v_l1"],
                 'unit_of_measurement': 'V',
-                'icon': 'mdi:flash',
-                'unique_id': f'ams_voltage_l1_{han_data["meter_serial"]}'
+                'icon': 'mdi:flash'
                 }
             }
 
@@ -356,9 +335,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_p"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[214:220])
@@ -375,9 +352,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_a_e_n"],
                     'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_active_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[227:233])
@@ -394,9 +369,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_p"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_import_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[240:246])
@@ -413,9 +386,7 @@ def parse_data(stored, data):
                     'meter_serial': han_data["meter_serial"],
                     'obis_code': han_data["obis_r_e_n"],
                     'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge',
-                    'unique_id': (f'ams_reactive_energy_export_'
-                                  f'{han_data["meter_serial"]}')
+                    'icon': 'mdi:gauge'
                     }
                 }
     return sensor_data

--- a/custom_components/ams/sensor.py
+++ b/custom_components/ams/sensor.py
@@ -88,7 +88,7 @@ class AmsSensor(Entity):
     @property
     def unique_id(self) -> str:
         """Return the unique id of the sensor."""
-        return f"{self._name}_{self._meter_id}"
+        return self._attributes["unique_id"]
 
     @property
     def name(self) -> str:

--- a/custom_components/ams/sensor.py
+++ b/custom_components/ams/sensor.py
@@ -3,7 +3,12 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.core import callback
 import custom_components.ams as amshub
-from .const import _LOGGER, AMS_NEW_SENSORS, DOMAIN, SIGNAL_NEW_AMS_SENSOR, SIGNAL_UPDATE_AMS
+from .const import (
+    _LOGGER,
+    AMS_NEW_SENSORS,
+    DOMAIN,
+    SIGNAL_NEW_AMS_SENSOR,
+    SIGNAL_UPDATE_AMS)
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
@@ -73,7 +78,7 @@ class AmsSensor(Entity):
     @property
     def unique_id(self) -> str:
         """Return the unique id of the sensor."""
-        return self._attributes.get('unique_id')
+        return f'{self._name}_{self._meter_id}'
 
     @property
     def name(self) -> str:

--- a/custom_components/ams/sensor.py
+++ b/custom_components/ams/sensor.py
@@ -3,7 +3,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.core import callback
 import custom_components.ams as amshub
-from .const import _LOGGER, DOMAIN, SIGNAL_NEW_AMS_SENSOR, SIGNAL_UPDATE_AMS
+from .const import _LOGGER, AMS_NEW_SENSORS, DOMAIN, SIGNAL_NEW_AMS_SENSOR, SIGNAL_UPDATE_AMS
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
@@ -12,13 +12,16 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     @callback
     def async_add_sensor():
         """Add AMS Sensor."""
+        sensors = []
+        sensor_states = {}
         data = hass.data[amshub.AMS_SENSORS]
+        sensors_to_add = hass.data[AMS_NEW_SENSORS]
         _LOGGER.debug('HUB in async_setup_entry-async_add_sensor= %s',
                       hass.data[DOMAIN].data)
         _LOGGER.debug('AMS_SENSORS in async_setup_entry-async_add_sensor= %s',
                       hass.data[amshub.AMS_SENSORS])
 
-        for sensor_name in list(data):
+        for sensor_name in list(sensors_to_add):
             sensor_states = {
                 'name': sensor_name,
                 'state': data[sensor_name].get('state'),
@@ -27,25 +30,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
             sensors.append(AmsSensor(hass, sensor_states))
         _LOGGER.debug('async_add_sensor in async_setup_entry')
         async_add_devices(sensors, True)
-
     async_dispatcher_connect(hass, SIGNAL_NEW_AMS_SENSOR, async_add_sensor)
-    sensor_states = {}
-    sensors = []
-    data = hass.data[amshub.AMS_SENSORS]
-    _LOGGER.debug('HUB in async_setup_entry= %s', hass.data[DOMAIN].data)
-    _LOGGER.debug('AMS_SENSORS in async_setup_entry= %s',
-                  hass.data[amshub.AMS_SENSORS])
-
-    for sensor_name in list(data):
-        sensor_states = {
-            'name': sensor_name,
-            'state': data[sensor_name].get('state'),
-            'attributes': data[sensor_name].get('attributes')
-            }
-        sensors.append(AmsSensor(hass, sensor_states))
-    _LOGGER.debug('async_add_devices in end of async_setup_entry')
-    async_add_devices(sensors)
-    return True
 
 
 async def async_remove_entry(hass, entry):

--- a/custom_components/ams/sensor.py
+++ b/custom_components/ams/sensor.py
@@ -88,7 +88,7 @@ class AmsSensor(Entity):
     @property
     def unique_id(self) -> str:
         """Return the unique id of the sensor."""
-        return self._attributes["unique_id"]
+        return self._attributes.get('unique_id')
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Get's rid of the following error:
```
2020-03-21 15:22:01 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 425, in _async_add_entity
raise HomeAssistantError(msg)
homeassistant.exceptions.HomeAssistantError: Entity id already exists: sensor.ams_active_power_import_none. Platform ams does not generate unique IDs
```
Fixes #12 