### PR TITLE
Make comport persistent by using /dev/serial/by_id. Black formatting

### DIFF
--- a/custom_components/ams/__init__.py
+++ b/custom_components/ams/__init__.py
@@ -41,7 +41,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(
                     CONF_METER_MANUFACTURER, default=DEFAULT_METER_MANUFACTURER
                 ): cv.string,
-                vol.Optional(CONF_PARITY, default=DEFAULT_PARITY): cv.string
+                vol.Optional(CONF_PARITY, default=DEFAULT_PARITY): cv.string,
             }
         )
     },
@@ -96,7 +96,7 @@ class AmsHub:
     def __init__(self, hass, entry):
         """Initialize the AMS hub."""
         self._hass = hass
-        port = (entry[CONF_SERIAL_PORT].split(":"))[0]
+        port = entry[CONF_SERIAL_PORT]
         _LOGGER.debug("Connecting to HAN using port %s", port)
         parity = entry.get(CONF_PARITY)
         self.meter_manufacturer = entry.get(CONF_METER_MANUFACTURER)
@@ -182,9 +182,10 @@ class AmsHub:
             match = []
             _LOGGER.debug("Testing for %s", meter)
             for i in range(len(pkg)):
-                if pkg[i] == meter[0] and pkg[i:i+len(meter)] == meter:
+                if pkg[i] == meter[0] and pkg[i : i + len(meter)] == meter:
                     match.append(meter)
             return meter in match
+
         if _test_meter(pkg, AIDON_METER_SEQ):
             _LOGGER.info("Detected Adion meter")
             return "aidon"
@@ -235,12 +236,11 @@ class AmsHub:
             # created, the most importent one is the meter_serial as this is
             # use to create the unique_id
             if self.missing_attrs(sensor_data) is True:
-                _LOGGER.debug("Missing some attributes waiting for new read from the serial")
-            else:
                 _LOGGER.debug(
-                    "Got %s new devices from the serial",
-                    len(new_devices)
+                    "Missing some attributes waiting for new read from the serial"
                 )
+            else:
+                _LOGGER.debug("Got %s new devices from the serial", len(new_devices))
                 _LOGGER.debug("DUMP %s", sensor_data)
                 async_dispatcher_send(self._hass, SIGNAL_NEW_AMS_SENSOR)
         else:

--- a/custom_components/ams/config_flow.py
+++ b/custom_components/ams/config_flow.py
@@ -1,5 +1,6 @@
 """Adds config flow for hass-AMS."""
 import logging
+import os
 
 import serial.tools.list_ports as devices
 import voluptuous as vol
@@ -34,25 +35,34 @@ class AmsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         portdata = await self.hass.async_add_executor_job(devices.comports)
-        ports = [
-            (comport.device + ": " + comport.description)
-            for comport in portdata]
+        ports = [(comport.device + ": " + comport.description) for comport in portdata]
 
         if user_input is not None:
+            user_selection = user_input[CONF_SERIAL_PORT]
+            port = portdata[ports.index(user_selection)]
+            serial_by_id = await self.hass.async_add_executor_job(
+                get_serial_by_id, port.device
+            )
+            user_input[CONF_SERIAL_PORT] = serial_by_id
             return self.async_create_entry(title="Norwegian AMS", data=user_input)
         _LOGGER.debug(ports)
-        return self.async_show_form(step_id="user", data_schema=vol.Schema({
-            vol.Required(CONF_SERIAL_PORT,
-                         default=None): vol.In(ports),
-            vol.Required(CONF_METER_MANUFACTURER,
-                         default=DEFAULT_METER_MANUFACTURER):
-                             vol.In(MANUFACTURER_OPTIONS),
-            vol.Optional(CONF_PARITY, default=DEFAULT_PARITY): vol.All(str)
-        }),
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_SERIAL_PORT, default=None): vol.In(ports),
+                    vol.Required(
+                        CONF_METER_MANUFACTURER, default=DEFAULT_METER_MANUFACTURER
+                    ): vol.In(MANUFACTURER_OPTIONS),
+                    vol.Optional(CONF_PARITY, default=DEFAULT_PARITY): vol.All(str),
+                }
+            ),
             description_placeholders={
                 CONF_SERIAL_PORT: ports,
-                CONF_METER_MANUFACTURER: MANUFACTURER_OPTIONS
-            }, errors=self._errors)
+                CONF_METER_MANUFACTURER: MANUFACTURER_OPTIONS,
+            },
+            errors=self._errors,
+        )
 
     async def async_step_import(self, import_config):
         """Import a config flow from configuration."""
@@ -61,3 +71,15 @@ class AmsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="singel_instance_allowed")
 
         return self.async_create_entry(title="configuration.yaml", data=import_config)
+
+
+def get_serial_by_id(dev_path):
+    """Return a /dev/serial/by-id match for given device if available."""
+    by_id = "/dev/serial/by-id"
+    if not os.path.isdir(by_id):
+        return dev_path
+
+    for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink()):
+        if os.path.realpath(path) == dev_path:
+            return path
+    return dev_path

--- a/custom_components/ams/parsers/__init__.py
+++ b/custom_components/ams/parsers/__init__.py
@@ -13,14 +13,11 @@ def field_type(default="", fields=None, enc=str, dec=None):
 
 def byte_decode(fields=None, count=4):
     """Data content decoder."""
-    _LOGGER.debug('fields= %s', fields)
+    _LOGGER.debug("fields= %s", fields)
     if count == 2:
-        data = (fields[0] << 8 | fields[1])
+        data = fields[0] << 8 | fields[1]
         return data
 
-    data = (fields[0] << 24 |
-            fields[1] << 16 |
-            fields[2] << 8 |
-            fields[3])
+    data = fields[0] << 24 | fields[1] << 16 | fields[2] << 8 | fields[3]
 
     return data

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -8,9 +8,16 @@ from datetime import datetime
 
 from crccheck.crc import CrcX25
 
-from ..const import (DATA_FLAG, FRAME_FLAG, LIST_TYPE_LONG_1PH,
-                     LIST_TYPE_LONG_3PH, LIST_TYPE_MINI, LIST_TYPE_SHORT_1PH,
-                     LIST_TYPE_SHORT_3PH, WEEKDAY_MAPPING)
+from ..const import (
+    DATA_FLAG,
+    FRAME_FLAG,
+    LIST_TYPE_LONG_1PH,
+    LIST_TYPE_LONG_3PH,
+    LIST_TYPE_MINI,
+    LIST_TYPE_SHORT_1PH,
+    LIST_TYPE_SHORT_3PH,
+    WEEKDAY_MAPPING,
+)
 from . import byte_decode, field_type
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,12 +26,14 @@ LIST_TYPE_SHORT_3PH_3W = 12
 LIST_TYPE_LONG_3PH_3W = 17
 
 METER_TYPE = {
-    6515: ('6515 1-phase Meter with CB on both lines and Earth '
-           'Fault Current Measurement'),
-    6525: '6525 3-phase Meter with CB and Earth Fault Measurement',
-    6534: '6534 3-phase Meter with CB and Neutral Current Measurement',
-    6540: '6540 3-phase CT Meter',
-    6550: '6550 3-phase CT Meter'
+    6515: (
+        "6515 1-phase Meter with CB on both lines and Earth "
+        "Fault Current Measurement"
+    ),
+    6525: "6525 3-phase Meter with CB and Earth Fault Measurement",
+    6534: "6534 3-phase Meter with CB and Neutral Current Measurement",
+    6540: "6540 3-phase CT Meter",
+    6550: "6550 3-phase CT Meter",
 }
 
 
@@ -45,21 +54,23 @@ def parse_data(stored, data):
         han_data["obis_a_p_p"] = field_type(".", fields=pkt[24:30])
         han_data["active_power_p"] = byte_decode(fields=pkt[31:35])
         sensor_data["ams_active_power_import"] = {
-            'state': han_data["active_power_p"],
-            'attributes': {
-                'meter_manufacturer': (stored["ams_active_power_import"]
-                                       ["attributes"]
-                                       ["meter_manufacturer"]),
-                'obis_code': han_data["obis_a_p_p"],
-                'meter_type': (stored["ams_active_power_import"]
-                               ["attributes"]
-                               ["meter_type"]),
-                'meter_serial': stored["ams_active_power_import"]
-                                      ["attributes"]
-                                      ["meter_serial"],
-                'unit_of_measurement': 'W',
-                'icon': 'mdi:gauge'
-            }
+            "state": han_data["active_power_p"],
+            "attributes": {
+                "meter_manufacturer": (
+                    stored["ams_active_power_import"]["attributes"][
+                        "meter_manufacturer"
+                    ]
+                ),
+                "obis_code": han_data["obis_a_p_p"],
+                "meter_type": (
+                    stored["ams_active_power_import"]["attributes"]["meter_type"]
+                ),
+                "meter_serial": stored["ams_active_power_import"]["attributes"][
+                    "meter_serial"
+                ],
+                "unit_of_measurement": "W",
+                "icon": "mdi:gauge",
+            },
         }
         stored.update(sensor_data)
         return stored, han_data
@@ -68,128 +79,128 @@ def parse_data(stored, data):
     han_data["meter_serial"] = field_type(fields=pkt[55:71], enc=chr)
     han_data["meter_type"] = field_type(fields=pkt[83:87], enc=chr, dec=int)
     han_data["meter_type_str"] = METER_TYPE.get(
-        field_type(fields=pkt[83:87], enc=chr, dec=int))
+        field_type(fields=pkt[83:87], enc=chr, dec=int)
+    )
     han_data["obis_a_p_p"] = field_type(".", fields=pkt[91:97])
     han_data["active_power_p"] = byte_decode(fields=pkt[98:102])
     sensor_data["ams_active_power_import"] = {
-        'state': han_data["active_power_p"],
-        'attributes': {
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'obis_code': han_data["obis_a_p_p"],
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["active_power_p"],
+        "attributes": {
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "obis_code": han_data["obis_a_p_p"],
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "unit_of_measurement": "W",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["obis_a_p_n"] = field_type(".", fields=pkt[112:118])
     han_data["active_power_n"] = byte_decode(fields=pkt[119:123])
     sensor_data["ams_active_power_export"] = {
-        'state': han_data["active_power_n"],
-        'attributes': {
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_a_p_n"],
-            'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["active_power_n"],
+        "attributes": {
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_a_p_n"],
+            "unit_of_measurement": "W",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["obis_r_p_p"] = field_type(".", fields=pkt[133:139])
     han_data["reactive_power_p"] = byte_decode(fields=pkt[140:144])
     sensor_data["ams_reactive_power_import"] = {
-        'state': han_data["reactive_power_p"],
-        'attributes': {
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_r_p_p"],
-            'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["reactive_power_p"],
+        "attributes": {
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_r_p_p"],
+            "unit_of_measurement": "VAr",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[154:160])
     han_data["reactive_power_n"] = byte_decode(fields=pkt[161:165])
     sensor_data["ams_reactive_power_export"] = {
-        'state': han_data["reactive_power_n"],
-        'attributes': {
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_r_p_n"],
-            'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["reactive_power_n"],
+        "attributes": {
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_r_p_n"],
+            "unit_of_measurement": "VAr",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[175:181])
     han_data["current_l1"] = byte_decode(fields=pkt[182:184], count=2) / 10
     sensor_data["ams_current_l1"] = {
-        'state': han_data["current_l1"],
-        'attributes': {
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_c_l1"],
-            'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac'
-            }
-        }
+        "state": han_data["current_l1"],
+        "attributes": {
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_c_l1"],
+            "unit_of_measurement": "A",
+            "icon": "mdi:current-ac",
+        },
+    }
 
-    if (list_type is LIST_TYPE_SHORT_3PH_3W or
-            LIST_TYPE_LONG_3PH_3W):
+    if list_type is LIST_TYPE_SHORT_3PH_3W or LIST_TYPE_LONG_3PH_3W:
 
         han_data["obis_c_l3"] = field_type(".", fields=pkt[194:200])
         han_data["current_l3"] = byte_decode(fields=pkt[201:203], count=2) / 10
         sensor_data["ams_current_l3"] = {
-            'state': han_data["current_l3"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_c_l3"],
-                'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
-                }
-            }
+            "state": han_data["current_l3"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_c_l3"],
+                "unit_of_measurement": "A",
+                "icon": "mdi:current-ac",
+            },
+        }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[213:219])
         han_data["voltage_l1"] = byte_decode(fields=pkt[220:222], count=2) / 10
         sensor_data["ams_voltage_l1"] = {
-            'state': han_data["voltage_l1"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l1"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l1"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l1"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[232:238])
         han_data["voltage_l2"] = byte_decode(fields=pkt[239:241], count=2) / 10
         sensor_data["ams_voltage_l2"] = {
-            'state': han_data["voltage_l2"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l2"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l2"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l2"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[251:257])
         han_data["voltage_l3"] = byte_decode(fields=pkt[258:260], count=2) / 10
         sensor_data["ams_voltage_l3"] = {
-            'state': han_data["voltage_l3"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l3"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l3"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l3"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         if list_type is LIST_TYPE_LONG_3PH_3W:
             meter_date_time_year = byte_decode(fields=pkt[278:280], count=2)
             meter_date_time_month = pkt[280]
@@ -198,144 +209,142 @@ def parse_data(stored, data):
             meter_date_time_hour = str(pkt[283]).zfill(2)
             meter_date_time_minute = str(pkt[284]).zfill(2)
             meter_date_time_seconds = str(pkt[285]).zfill(2)
-            han_data["meter_date_time"] = (str(meter_date_time_year) +
-                                           '-' + str(meter_date_time_month) +
-                                           '-' + str(meter_date_time_date) +
-                                           ' ' + meter_date_time_hour +
-                                           ':' + meter_date_time_minute +
-                                           ':' + meter_date_time_seconds)
+            han_data["meter_date_time"] = (
+                str(meter_date_time_year)
+                + "-"
+                + str(meter_date_time_month)
+                + "-"
+                + str(meter_date_time_date)
+                + " "
+                + meter_date_time_hour
+                + ":"
+                + meter_date_time_minute
+                + ":"
+                + meter_date_time_seconds
+            )
             han_data["obis_a_e_p"] = field_type(".", fields=pkt[294:300])
-            han_data["active_energy_p"] = byte_decode(
-                fields=pkt[301:305]) / 100
+            han_data["active_energy_p"] = byte_decode(fields=pkt[301:305]) / 100
             sensor_data["ams_active_energy_import"] = {
-                'state': han_data["active_energy_p"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_p"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["active_energy_p"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_p"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[315:321])
-            han_data["active_energy_n"] = byte_decode(
-                fields=pkt[322:326]) / 100
+            han_data["active_energy_n"] = byte_decode(fields=pkt[322:326]) / 100
             sensor_data["ams_active_energy_export"] = {
-                'state': han_data["active_energy_n"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_n"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["active_energy_n"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_n"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[336:342])
-            han_data["reactive_energy_p"] = byte_decode(
-                fields=pkt[343:347]) / 100
+            han_data["reactive_energy_p"] = byte_decode(fields=pkt[343:347]) / 100
             sensor_data["ams_reactive_energy_import"] = {
-                'state': han_data["reactive_energy_p"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["reactive_energy_p"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[357:363])
-            han_data["reactive_energy_n"] = byte_decode(
-                fields=pkt[364:368]) / 100
+            han_data["reactive_energy_n"] = byte_decode(fields=pkt[364:368]) / 100
             sensor_data["ams_reactive_energy_export"] = {
-                'state': han_data["reactive_energy_n"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_r_e_n"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["reactive_energy_n"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_r_e_n"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
             }
 
-    if (list_type is LIST_TYPE_SHORT_3PH or
-            list_type is LIST_TYPE_LONG_3PH):
+    if list_type is LIST_TYPE_SHORT_3PH or list_type is LIST_TYPE_LONG_3PH:
 
         han_data["obis_c_l2"] = field_type(".", fields=pkt[194:200])
         han_data["current_l2"] = byte_decode(fields=pkt[202:204], count=2) / 10
         sensor_data["ams_current_l2"] = {
-            'state': han_data["current_l2"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_c_l2"],
-                'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
-                }
-            }
+            "state": han_data["current_l2"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_c_l2"],
+                "unit_of_measurement": "A",
+                "icon": "mdi:current-ac",
+            },
+        }
         han_data["obis_c_l3"] = field_type(".", fields=pkt[213:219])
         han_data["current_l3"] = byte_decode(fields=pkt[220:222], count=2) / 10
         sensor_data["ams_current_l3"] = {
-            'state': han_data["current_l3"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_c_l3"],
-                'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
-                }
-            }
+            "state": han_data["current_l3"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_c_l3"],
+                "unit_of_measurement": "A",
+                "icon": "mdi:current-ac",
+            },
+        }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[232:238])
         han_data["voltage_l1"] = byte_decode(fields=pkt[239:241], count=2) / 10
         sensor_data["ams_voltage_l1"] = {
-            'state': han_data["voltage_l1"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l1"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l1"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l1"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[251:257])
         han_data["voltage_l2"] = byte_decode(fields=pkt[258:260], count=2) / 10
         sensor_data["ams_voltage_l2"] = {
-            'state': han_data["voltage_l2"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l2"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l2"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l2"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[270:276])
         han_data["voltage_l3"] = byte_decode(fields=pkt[277:279], count=2) / 10
         sensor_data["ams_voltage_l3"] = {
-            'state': han_data["voltage_l3"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l3"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l3"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l3"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         if list_type is LIST_TYPE_LONG_3PH_3W:
             meter_date_time_year = byte_decode(fields=pkt[297:299], count=2)
             meter_date_time_month = pkt[299]
@@ -344,91 +353,89 @@ def parse_data(stored, data):
             meter_date_time_hour = str(pkt[302]).zfill(2)
             meter_date_time_minute = str(pkt[303]).zfill(2)
             meter_date_time_seconds = str(pkt[304]).zfill(2)
-            han_data["meter_date_time"] = (str(meter_date_time_year) +
-                                           '-' + str(meter_date_time_month) +
-                                           '-' + str(meter_date_time_date) +
-                                           ' ' + meter_date_time_hour +
-                                           ':' + meter_date_time_minute +
-                                           ':' + meter_date_time_seconds)
+            han_data["meter_date_time"] = (
+                str(meter_date_time_year)
+                + "-"
+                + str(meter_date_time_month)
+                + "-"
+                + str(meter_date_time_date)
+                + " "
+                + meter_date_time_hour
+                + ":"
+                + meter_date_time_minute
+                + ":"
+                + meter_date_time_seconds
+            )
             han_data["obis_a_e_p"] = field_type(".", fields=pkt[313:319])
-            han_data["active_energy_p"] = byte_decode(
-                fields=pkt[320:324]) / 100
+            han_data["active_energy_p"] = byte_decode(fields=pkt[320:324]) / 100
             sensor_data["ams_active_energy_import"] = {
-                'state': han_data["active_energy_p"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_p"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["active_energy_p"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_p"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[334:340])
-            han_data["active_energy_n"] = byte_decode(
-                fields=pkt[341:345]) / 100
+            han_data["active_energy_n"] = byte_decode(fields=pkt[341:345]) / 100
             sensor_data["ams_active_energy_export"] = {
-                'state': han_data["active_energy_n"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_n"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["active_energy_n"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_n"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[355:361])
-            han_data["reactive_energy_p"] = byte_decode(
-                fields=pkt[362:366]) / 100
+            han_data["reactive_energy_p"] = byte_decode(fields=pkt[362:366]) / 100
             sensor_data["ams_reactive_energy_import"] = {
-                'state': han_data["reactive_energy_p"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["reactive_energy_p"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[376:3382])
-            han_data["reactive_energy_n"] = byte_decode(
-                fields=pkt[383:387]) / 100
+            han_data["reactive_energy_n"] = byte_decode(fields=pkt[383:387]) / 100
             sensor_data["ams_reactive_energy_export"] = {
-                'state': han_data["reactive_energy_n"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_r_e_n"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["reactive_energy_n"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_r_e_n"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
             }
 
-    if (list_type is LIST_TYPE_SHORT_1PH or
-            list_type is LIST_TYPE_LONG_1PH):
+    if list_type is LIST_TYPE_SHORT_1PH or list_type is LIST_TYPE_LONG_1PH:
         han_data["obis_v_l1"] = field_type(".", fields=pkt[194:200])
         han_data["voltage_l1"] = byte_decode(fields=pkt[201:203], count=2) / 10
         sensor_data["ams_voltage_l1"] = {
-            'state': han_data["voltage_l1"],
-            'attributes': {
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l1"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l1"],
+            "attributes": {
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l1"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
 
         if list_type is LIST_TYPE_LONG_1PH:
             meter_date_time_year = byte_decode(fields=pkt[221:223], count=2)
@@ -438,76 +445,75 @@ def parse_data(stored, data):
             meter_date_time_hour = str(pkt[226]).zfill(2)
             meter_date_time_minute = str(pkt[227]).zfill(2)
             meter_date_time_seconds = str(pkt[228]).zfill(2)
-            han_data["meter_date_time"] = (str(meter_date_time_year) +
-                                           '-' + str(meter_date_time_month) +
-                                           '-' + str(meter_date_time_date) +
-                                           ' ' + meter_date_time_hour +
-                                           ':' + meter_date_time_minute +
-                                           ':' + meter_date_time_seconds)
+            han_data["meter_date_time"] = (
+                str(meter_date_time_year)
+                + "-"
+                + str(meter_date_time_month)
+                + "-"
+                + str(meter_date_time_date)
+                + " "
+                + meter_date_time_hour
+                + ":"
+                + meter_date_time_minute
+                + ":"
+                + meter_date_time_seconds
+            )
             han_data["obis_a_e_p"] = field_type(".", fields=pkt[237:243])
-            han_data["active_energy_p"] = byte_decode(
-                fields=pkt[244:248]) / 100
+            han_data["active_energy_p"] = byte_decode(fields=pkt[244:248]) / 100
             sensor_data["ams_active_energy_import"] = {
-                'state': han_data["active_energy_p"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_p"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["active_energy_p"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_p"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
+            }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[258:264])
-            han_data["active_energy_n"] = byte_decode(
-                fields=pkt[265:269]) / 100
+            han_data["active_energy_n"] = byte_decode(fields=pkt[265:269]) / 100
             sensor_data["ams_active_energy_export"] = {
-                'state': han_data["active_energy_n"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_n"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["active_energy_n"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_n"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
+            }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[279:285])
-            han_data["reactive_energy_p"] = byte_decode(
-                fields=pkt[286:290]) / 100
+            han_data["reactive_energy_p"] = byte_decode(fields=pkt[286:290]) / 100
             sensor_data["ams_reactive_energy_import"] = {
-                'state': han_data["reactive_energy_p"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_r_e_p"],
-                    'unit_of_measurement': 'kVAh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["reactive_energy_p"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_r_e_p"],
+                    "unit_of_measurement": "kVAh",
+                    "icon": "mdi:gauge",
+                },
+            }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[300:306])
-            han_data["reactive_energy_n"] = byte_decode(
-                fields=pkt[307:311]) / 100
+            han_data["reactive_energy_n"] = byte_decode(fields=pkt[307:311]) / 100
             sensor_data["ams_reactive_energy_export"] = {
-                'state': han_data["reactive_energy_n"],
-                'attributes': {
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_r_e_n"],
-                    'unit_of_measurement': 'kVAh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["reactive_energy_n"],
+                "attributes": {
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_r_e_n"],
+                    "unit_of_measurement": "kVAh",
+                    "icon": "mdi:gauge",
+                },
+            }
 
     stored.update(sensor_data)
     return stored, han_data
@@ -520,32 +526,34 @@ def test_valid_data(data):
         return False
 
     if len(data) > 377 or len(data) < 44:
-        _LOGGER.debug('Invalid packet size %s', len(data))
+        _LOGGER.debug("Invalid packet size %s", len(data))
         return False
 
     if not data[0] and data[-1] == FRAME_FLAG:
-        _LOGGER.debug("%s Recieved %s bytes of %s data",
-                      datetime.now().isoformat(),
-                      len(data), False)
+        _LOGGER.debug(
+            "%s Recieved %s bytes of %s data",
+            datetime.now().isoformat(),
+            len(data),
+            False,
+        )
         return False
 
     header_checksum = CrcX25.calc(bytes(data[1:7]))
-    read_header_checksum = (data[8] << 8 | data[7])
+    read_header_checksum = data[8] << 8 | data[7]
 
     if header_checksum != read_header_checksum:
-        _LOGGER.debug('Invalid header CRC check')
+        _LOGGER.debug("Invalid header CRC check")
         return False
 
     frame_checksum = CrcX25.calc(bytes(data[1:-3]))
-    read_frame_checksum = (data[-2] << 8 | data[-3])
+    read_frame_checksum = data[-2] << 8 | data[-3]
 
     if frame_checksum != read_frame_checksum:
-        _LOGGER.debug('Invalid frame CRC check')
+        _LOGGER.debug("Invalid frame CRC check")
         return False
 
     if data[9:13] != DATA_FLAG:
-        _LOGGER.debug('Data does not start with %s: %s',
-                      DATA_FLAG, data[9:13])
+        _LOGGER.debug("Data does not start with %s: %s", DATA_FLAG, data[9:13])
         return False
 
     packet_size = len(data)
@@ -553,8 +561,10 @@ def test_valid_data(data):
 
     if packet_size != read_packet_size:
         _LOGGER.debug(
-            'Packet size does not match read packet size: %s : %s',
-            packet_size, read_packet_size)
+            "Packet size does not match read packet size: %s : %s",
+            packet_size,
+            read_packet_size,
+        )
         return False
 
     return True

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -8,19 +8,26 @@ from datetime import datetime
 
 from crccheck.crc import CrcX25
 
-from ..const import (DATA_FLAG, FRAME_FLAG, LIST_TYPE_LONG_1PH,
-                     LIST_TYPE_LONG_3PH, LIST_TYPE_MINI, LIST_TYPE_SHORT_1PH,
-                     LIST_TYPE_SHORT_3PH, WEEKDAY_MAPPING)
+from ..const import (
+    DATA_FLAG,
+    FRAME_FLAG,
+    LIST_TYPE_LONG_1PH,
+    LIST_TYPE_LONG_3PH,
+    LIST_TYPE_MINI,
+    LIST_TYPE_SHORT_1PH,
+    LIST_TYPE_SHORT_3PH,
+    WEEKDAY_MAPPING,
+)
 from . import byte_decode, field_type
 
 _LOGGER = logging.getLogger(__name__)
 
 METER_TYPE = {
-    "MA105H2E": 'Domestic 1 Phase 230V/400V meter',
-    "MA304H3E": 'Domestic/Industrial 3 Phase 230V 3-Wire meter',
-    "MA304H4": 'Domestic/Industrial 3 Phase 400V 4-Wire meter',
-    "MA304T4": 'Industrial 3 Phase 230V 3-Wire meter',
-    "MA304T3": 'Industrial 3 Phase 400V 4-Wire meter'
+    "MA105H2E": "Domestic 1 Phase 230V/400V meter",
+    "MA304H3E": "Domestic/Industrial 3 Phase 230V 3-Wire meter",
+    "MA304H4": "Domestic/Industrial 3 Phase 400V 4-Wire meter",
+    "MA304T4": "Industrial 3 Phase 230V 3-Wire meter",
+    "MA304T3": "Industrial 3 Phase 400V 4-Wire meter",
 }
 
 
@@ -38,24 +45,31 @@ def parse_data(stored, data):
     date_time_hour = str(pkt[24]).zfill(2)
     date_time_minute = str(pkt[25]).zfill(2)
     date_time_seconds = str(pkt[26]).zfill(2)
-    date_time_str = (str(date_time_year) +
-                     '-' + str(date_time_month) +
-                     '-' + str(date_time_date) +
-                     ' ' + date_time_hour +
-                     ':' + date_time_minute +
-                     ':' + date_time_seconds)
+    date_time_str = (
+        str(date_time_year)
+        + "-"
+        + str(date_time_month)
+        + "-"
+        + str(date_time_date)
+        + " "
+        + date_time_hour
+        + ":"
+        + date_time_minute
+        + ":"
+        + date_time_seconds
+    )
     han_data["date_time"] = date_time_str
     list_type = pkt[32]
     han_data["list_type"] = list_type
     if list_type is LIST_TYPE_MINI:
         han_data["active_power_p"] = byte_decode(fields=pkt[34:38])
         sensor_data["ams_active_power_import"] = {
-            'state': han_data["active_power_p"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'unit_of_measurement': 'W',
-                'icon': 'mdi:gauge'
-            }
+            "state": han_data["active_power_p"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "unit_of_measurement": "W",
+                "icon": "mdi:gauge",
+            },
         }
         stored.update(sensor_data)
         return stored, han_data
@@ -63,119 +77,117 @@ def parse_data(stored, data):
     han_data["obis_list_version"] = field_type(fields=pkt[35:42], enc=chr)
     han_data["meter_serial"] = field_type(fields=pkt[44:60], enc=chr)
     han_data["meter_type"] = field_type(fields=pkt[62:70], enc=chr)
-    han_data["meter_type_str"] = METER_TYPE.get(
-        field_type(fields=pkt[62:70], enc=chr))
+    han_data["meter_type_str"] = METER_TYPE.get(field_type(fields=pkt[62:70], enc=chr))
     han_data["active_power_n"] = byte_decode(fields=pkt[76:80]) / 100
     sensor_data["ams_active_power_export"] = {
-        'state': han_data["active_power_n"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["active_power_n"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "unit_of_measurement": "W",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["reactive_power_p"] = byte_decode(fields=pkt[81:85])
     sensor_data["ams_reactive_power_import"] = {
-        'state': han_data["reactive_power_p"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["reactive_power_p"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "unit_of_measurement": "VAr",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["reactive_power_n"] = byte_decode(fields=pkt[86:90])
     sensor_data["ams_reactive_power_export"] = {
-        'state': han_data["reactive_power_n"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'unit_of_measurement': 'VAr',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["reactive_power_n"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "unit_of_measurement": "VAr",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["current_l1"] = byte_decode(fields=pkt[91:95]) / 1000
     sensor_data["ams_current_l1"] = {
-        'state': han_data["current_l1"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac'
-            }
-        }
+        "state": han_data["current_l1"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "unit_of_measurement": "A",
+            "icon": "mdi:current-ac",
+        },
+    }
 
-    if (list_type is LIST_TYPE_SHORT_3PH or
-            list_type is LIST_TYPE_LONG_3PH):
+    if list_type is LIST_TYPE_SHORT_3PH or list_type is LIST_TYPE_LONG_3PH:
         han_data["current_l2"] = byte_decode(fields=pkt[96:100]) / 1000
         sensor_data["ams_current_l2"] = {
-            'state': han_data["current_l2"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
-                }
-            }
+            "state": han_data["current_l2"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "unit_of_measurement": "A",
+                "icon": "mdi:current-ac",
+            },
+        }
         han_data["current_l3"] = byte_decode(fields=pkt[101:105]) / 1000
         sensor_data["ams_current_l3"] = {
-            'state': han_data["current_l3"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
-                }
-            }
+            "state": han_data["current_l3"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "unit_of_measurement": "A",
+                "icon": "mdi:current-ac",
+            },
+        }
         han_data["voltage_l1"] = byte_decode(fields=pkt[106:110]) / 10
         sensor_data["ams_voltage_l1"] = {
-            'state': han_data["voltage_l1"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l1"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         han_data["voltage_l2"] = byte_decode(fields=pkt[111:115]) / 10
         sensor_data["ams_voltage_l2"] = {
-            'state': han_data["voltage_l2"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l2"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         han_data["voltage_l3"] = byte_decode(fields=pkt[116:120]) / 10
         sensor_data["ams_voltage_l3"] = {
-            'state': han_data["voltage_l3"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l3"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         if list_type == LIST_TYPE_LONG_3PH:
             meter_date_time_year = byte_decode(fields=pkt[122:124], count=2)
             meter_date_time_month = pkt[124]
@@ -184,88 +196,86 @@ def parse_data(stored, data):
             meter_date_time_hour = str(pkt[127]).zfill(2)
             meter_date_time_minute = str(pkt[128]).zfill(2)
             meter_date_time_seconds = str(pkt[129]).zfill(2)
-            han_data["meter_date_time"] = (str(meter_date_time_year) +
-                                           '-' + str(meter_date_time_month) +
-                                           '-' + str(meter_date_time_date) +
-                                           ' ' + meter_date_time_hour +
-                                           ':' + meter_date_time_minute +
-                                           ':' + meter_date_time_seconds)
-            han_data["active_energy_p"] = byte_decode(
-                fields=pkt[135:139]) / 1000
+            han_data["meter_date_time"] = (
+                str(meter_date_time_year)
+                + "-"
+                + str(meter_date_time_month)
+                + "-"
+                + str(meter_date_time_date)
+                + " "
+                + meter_date_time_hour
+                + ":"
+                + meter_date_time_minute
+                + ":"
+                + meter_date_time_seconds
+            )
+            han_data["active_energy_p"] = byte_decode(fields=pkt[135:139]) / 1000
             sensor_data["ams_active_energy_import"] = {
-                'state': han_data["active_energy_p"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["active_energy_p"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
             }
-            han_data["active_energy_n"] = byte_decode(
-                fields=pkt[140:144]) / 1000
+            han_data["active_energy_n"] = byte_decode(fields=pkt[140:144]) / 1000
             sensor_data["ams_active_energy_export"] = {
-                'state': han_data["active_energy_n"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["active_energy_n"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
             }
-            han_data["reactive_energy_p"] = byte_decode(
-                fields=pkt[145:149]) / 1000
+            han_data["reactive_energy_p"] = byte_decode(fields=pkt[145:149]) / 1000
             sensor_data["ams_reactive_energy_import"] = {
-                'state': han_data["reactive_energy_p"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["reactive_energy_p"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
             }
-            han_data["reactive_energy_n"] = byte_decode(
-                fields=pkt[150:154]) / 1000
+            han_data["reactive_energy_n"] = byte_decode(fields=pkt[150:154]) / 1000
             sensor_data["ams_reactive_energy_export"] = {
-                'state': han_data["reactive_energy_n"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["reactive_energy_n"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
             }
 
-    if (list_type is LIST_TYPE_SHORT_1PH or
-            list_type is LIST_TYPE_LONG_1PH):
+    if list_type is LIST_TYPE_SHORT_1PH or list_type is LIST_TYPE_LONG_1PH:
 
         han_data["voltage_l1"] = byte_decode(fields=pkt[96:100]) / 10
         sensor_data["ams_voltage_l1"] = {
-            'state': han_data["voltage_l1"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l1"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
 
         if list_type == LIST_TYPE_LONG_1PH:
             meter_date_time_year = byte_decode(fields=pkt[102:104], count=2)
@@ -275,72 +285,71 @@ def parse_data(stored, data):
             meter_date_time_hour = str(pkt[107]).zfill(2)
             meter_date_time_minute = str(pkt[108]).zfill(2)
             meter_date_time_seconds = str(pkt[109]).zfill(2)
-            han_data["meter_date_time"] = (str(meter_date_time_year) +
-                                           '-' + str(meter_date_time_month) +
-                                           '-' + str(meter_date_time_date) +
-                                           ' ' + meter_date_time_hour +
-                                           ':' + meter_date_time_minute +
-                                           ':' + meter_date_time_seconds)
-            han_data["active_energy_p"] = byte_decode(
-                fields=pkt[115:120]) / 1000
+            han_data["meter_date_time"] = (
+                str(meter_date_time_year)
+                + "-"
+                + str(meter_date_time_month)
+                + "-"
+                + str(meter_date_time_date)
+                + " "
+                + meter_date_time_hour
+                + ":"
+                + meter_date_time_minute
+                + ":"
+                + meter_date_time_seconds
+            )
+            han_data["active_energy_p"] = byte_decode(fields=pkt[115:120]) / 1000
             sensor_data["ams_active_energy_import"] = {
-                'state': han_data["active_energy_p"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
-            han_data["active_energy_n"] = byte_decode(
-                fields=pkt[121:125]) / 1000
+                "state": han_data["active_energy_p"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
+            }
+            han_data["active_energy_n"] = byte_decode(fields=pkt[121:125]) / 1000
             sensor_data["ams_active_energy_export"] = {
-                'state': han_data["active_energy_n"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
-            han_data["reactive_energy_p"] = byte_decode(
-                fields=pkt[126:130]) / 1000
+                "state": han_data["active_energy_n"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
+            }
+            han_data["reactive_energy_p"] = byte_decode(fields=pkt[126:130]) / 1000
             sensor_data["ams_reactive_energy_import"] = {
-                'state': han_data["reactive_energy_p"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
-            han_data["reactive_energy_n"] = byte_decode(
-                fields=pkt[131:135]) / 1000
+                "state": han_data["reactive_energy_p"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
+            }
+            han_data["reactive_energy_n"] = byte_decode(fields=pkt[131:135]) / 1000
             sensor_data["ams_reactive_energy_export"] = {
-                'state': han_data["reactive_energy_n"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["reactive_energy_n"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
+            }
     stored.update(sensor_data)
     return stored, han_data
 
@@ -352,32 +361,34 @@ def test_valid_data(data):
         return False
 
     if len(data) > 157 or len(data) < 41:
-        _LOGGER.debug('Invalid packet size %s', len(data))
+        _LOGGER.debug("Invalid packet size %s", len(data))
         return False
 
     if not data[0] and data[-1] == FRAME_FLAG:
-        _LOGGER.debug("%s Recieved %s bytes of %s data",
-                      datetime.now().isoformat(),
-                      len(data), False)
+        _LOGGER.debug(
+            "%s Recieved %s bytes of %s data",
+            datetime.now().isoformat(),
+            len(data),
+            False,
+        )
         return False
 
     header_checksum = CrcX25.calc(bytes(data[1:7]))
-    read_header_checksum = (data[8] << 8 | data[7])
+    read_header_checksum = data[8] << 8 | data[7]
 
     if header_checksum != read_header_checksum:
-        _LOGGER.debug('Invalid header CRC check')
+        _LOGGER.debug("Invalid header CRC check")
         return False
 
     frame_checksum = CrcX25.calc(bytes(data[1:-3]))
-    read_frame_checksum = (data[-2] << 8 | data[-3])
+    read_frame_checksum = data[-2] << 8 | data[-3]
 
     if frame_checksum != read_frame_checksum:
-        _LOGGER.debug('Invalid frame CRC check')
+        _LOGGER.debug("Invalid frame CRC check")
         return False
 
     if data[9:13] != DATA_FLAG:
-        _LOGGER.debug('Data does not start with %s: %s',
-                      DATA_FLAG, data[9:13])
+        _LOGGER.debug("Data does not start with %s: %s", DATA_FLAG, data[9:13])
         return False
 
     packet_size = len(data)
@@ -385,8 +396,10 @@ def test_valid_data(data):
 
     if packet_size != read_packet_size:
         _LOGGER.debug(
-            'Packet size does not match read packet size: %s : %s',
-            packet_size, read_packet_size)
+            "Packet size does not match read packet size: %s : %s",
+            packet_size,
+            read_packet_size,
+        )
         return False
 
     return True

--- a/custom_components/ams/parsers/kamstrup.py
+++ b/custom_components/ams/parsers/kamstrup.py
@@ -20,11 +20,11 @@ LIST_TYPE_LONG_3PH = 35
 
 
 METER_TYPE = {
-    6861111: 'Omnipower 1 Phase Direct meter',
-    6841121: 'Omnipower 3 Phase 3-Wire Direct meter',
-    6841131: 'Omnipower 3 Phase 4-Wire Direct meter',
-    6851121: 'Omnipower 3 Phase CT 3-Wire Direct meter',
-    6851131: 'Omnipower 3 Phase CT 4-Wire Direct meter'
+    6861111: "Omnipower 1 Phase Direct meter",
+    6841121: "Omnipower 3 Phase 3-Wire Direct meter",
+    6841131: "Omnipower 3 Phase 4-Wire Direct meter",
+    6851121: "Omnipower 3 Phase CT 3-Wire Direct meter",
+    6851131: "Omnipower 3 Phase CT 4-Wire Direct meter",
 }
 
 
@@ -41,12 +41,19 @@ def parse_data(stored, data):
     date_time_hour = str(pkt[22]).zfill(2)
     date_time_minute = str(pkt[23]).zfill(2)
     date_time_seconds = str(pkt[24]).zfill(2)
-    date_time_str = (str(date_time_year) +
-                     '-' + str(date_time_month) +
-                     '-' + str(date_time_date) +
-                     ' ' + date_time_hour +
-                     ':' + date_time_minute +
-                     ':' + date_time_seconds)
+    date_time_str = (
+        str(date_time_year)
+        + "-"
+        + str(date_time_month)
+        + "-"
+        + str(date_time_date)
+        + " "
+        + date_time_hour
+        + ":"
+        + date_time_minute
+        + ":"
+        + date_time_seconds
+    )
     han_data["date_time"] = date_time_str
     han_data["day_of_week"] = WEEKDAY_MAPPING.get(pkt[21])
     list_type = pkt[30]
@@ -57,154 +64,153 @@ def parse_data(stored, data):
     han_data["obis_m_t"] = field_type(".", fields=pkt[75:80])
     han_data["meter_type"] = field_type(fields=pkt[83:101], enc=chr)
     han_data["meter_type_str"] = METER_TYPE.get(
-        field_type(fields=pkt[83:90], enc=chr, dec=int))
+        field_type(fields=pkt[83:90], enc=chr, dec=int)
+    )
     han_data["obis_a_p_p"] = field_type(".", fields=pkt[103:109])
     han_data["active_power_p"] = byte_decode(fields=pkt[110:114])
     sensor_data["ams_active_power_import"] = {
-        'state': han_data["active_power_p"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_a_p_p"],
-            'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["active_power_p"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_a_p_p"],
+            "unit_of_measurement": "W",
+            "icon": "mdi:gauge",
+        },
+    }
 
     han_data["obis_a_p_n"] = field_type(".", fields=pkt[116:122])
     han_data["active_power_n"] = byte_decode(fields=pkt[123:127])
     sensor_data["ams_active_power_export"] = {
-        'state': han_data["active_power_n"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_a_p_n"],
-            'unit_of_measurement': 'W',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["active_power_n"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_a_p_n"],
+            "unit_of_measurement": "W",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["obis_r_p_p"] = field_type(".", fields=pkt[129:135])
     han_data["reactive_power_p"] = byte_decode(fields=pkt[136:140])
     sensor_data["ams_reactive_power_import"] = {
-        'state': han_data["reactive_power_p"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_r_p_p"],
-            'unit_of_measurement': 'kVAr',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["reactive_power_p"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_r_p_p"],
+            "unit_of_measurement": "kVAr",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["obis_r_p_n"] = field_type(".", fields=pkt[142:148])
     han_data["reactive_power_n"] = byte_decode(fields=pkt[149:153])
     sensor_data["ams_reactive_power_export"] = {
-        'state': han_data["reactive_power_n"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_r_p_n"],
-            'unit_of_measurement': 'kVAr',
-            'icon': 'mdi:gauge'
-            }
-        }
+        "state": han_data["reactive_power_n"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_r_p_n"],
+            "unit_of_measurement": "kVAr",
+            "icon": "mdi:gauge",
+        },
+    }
     han_data["obis_c_l1"] = field_type(".", fields=pkt[155:161])
     han_data["current_l1"] = byte_decode(fields=pkt[162:166]) / 100
     sensor_data["ams_current_l1"] = {
-        'state': han_data["current_l1"],
-        'attributes': {
-            'timestamp': han_data["date_time"],
-            'meter_manufacturer': han_data["obis_list_version"].title(),
-            'meter_type': han_data["meter_type_str"],
-            'meter_serial': han_data["meter_serial"],
-            'obis_code': han_data["obis_c_l1"],
-            'unit_of_measurement': 'A',
-            'icon': 'mdi:current-ac'
-            }
-        }
+        "state": han_data["current_l1"],
+        "attributes": {
+            "timestamp": han_data["date_time"],
+            "meter_manufacturer": han_data["obis_list_version"].title(),
+            "meter_type": han_data["meter_type_str"],
+            "meter_serial": han_data["meter_serial"],
+            "obis_code": han_data["obis_c_l1"],
+            "unit_of_measurement": "A",
+            "icon": "mdi:current-ac",
+        },
+    }
 
-    if (list_type is LIST_TYPE_SHORT_3PH or
-            list_type is LIST_TYPE_LONG_3PH):
+    if list_type is LIST_TYPE_SHORT_3PH or list_type is LIST_TYPE_LONG_3PH:
         han_data["obis_c_l2"] = field_type(".", fields=pkt[168:174])
         han_data["current_l2"] = byte_decode(fields=pkt[175:179]) / 100
         sensor_data["ams_current_l2"] = {
-            'state': han_data["current_l2"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_c_l2"],
-                'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
-                }
-            }
+            "state": han_data["current_l2"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_c_l2"],
+                "unit_of_measurement": "A",
+                "icon": "mdi:current-ac",
+            },
+        }
         han_data["obis_c_l3"] = field_type(".", fields=pkt[181:187])
         han_data["current_l3"] = byte_decode(fields=pkt[188:192]) / 100
         sensor_data["ams_current_l3"] = {
-            'state': han_data["current_l3"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_c_l3"],
-                'unit_of_measurement': 'A',
-                'icon': 'mdi:current-ac'
-                }
-            }
+            "state": han_data["current_l3"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_c_l3"],
+                "unit_of_measurement": "A",
+                "icon": "mdi:current-ac",
+            },
+        }
         han_data["obis_v_l1"] = field_type(".", fields=pkt[194:200])
         han_data["voltage_l1"] = byte_decode(fields=pkt[201:203], count=2)
         sensor_data["ams_voltage_l1"] = {
-            'state': han_data["voltage_l1"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l1"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l1"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l1"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         han_data["obis_v_l2"] = field_type(".", fields=pkt[205:211])
         han_data["voltage_l2"] = byte_decode(fields=pkt[212:214], count=2)
         sensor_data["ams_voltage_l2"] = {
-            'state': han_data["voltage_l2"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l2"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l2"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l2"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         han_data["obis_v_l3"] = field_type(".", fields=pkt[216:222])
         han_data["voltage_l3"] = byte_decode(fields=pkt[223:225], count=2)
         sensor_data["ams_voltage_l3"] = {
-            'state': han_data["voltage_l3"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l3"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l3"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l3"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
         if list_type == LIST_TYPE_LONG_3PH:
-            han_data["obis_meter_date_time"] = field_type(
-                ".", fields=pkt[227:233])
+            han_data["obis_meter_date_time"] = field_type(".", fields=pkt[227:233])
             meter_date_time_year = byte_decode(fields=pkt[235:237], count=2)
             meter_date_time_month = pkt[237]
             meter_date_time_date = pkt[238]
@@ -212,102 +218,99 @@ def parse_data(stored, data):
             meter_date_time_hour = str(pkt[240]).zfill(2)
             meter_date_time_minute = str(pkt[241]).zfill(2)
             meter_date_time_seconds = str(pkt[242]).zfill(2)
-            han_data["meter_date_time"] = (str(meter_date_time_year) +
-                                           '-' + str(meter_date_time_month) +
-                                           '-' + str(meter_date_time_date) +
-                                           ' ' + meter_date_time_hour +
-                                           ':' + meter_date_time_minute +
-                                           ':' + meter_date_time_seconds)
+            han_data["meter_date_time"] = (
+                str(meter_date_time_year)
+                + "-"
+                + str(meter_date_time_month)
+                + "-"
+                + str(meter_date_time_date)
+                + " "
+                + meter_date_time_hour
+                + ":"
+                + meter_date_time_minute
+                + ":"
+                + meter_date_time_seconds
+            )
             han_data["obis_a_e_p"] = field_type(".", fields=pkt[249:255])
-            han_data["active_energy_p"] = byte_decode(
-                fields=pkt[256:260]) / 100
+            han_data["active_energy_p"] = byte_decode(fields=pkt[256:260]) / 100
             sensor_data["ams_active_energy_import"] = {
-                'state': han_data["active_energy_p"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_p"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["active_energy_p"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_p"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[262:268])
-            han_data["active_energy_n"] = byte_decode(
-                fields=pkt[269:273]) / 100
+            han_data["active_energy_n"] = byte_decode(fields=pkt[269:273]) / 100
             sensor_data["ams_active_energy_export"] = {
-                'state': han_data["active_energy_n"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_n"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["active_energy_n"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_n"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[275:281])
-            han_data["reactive_energy_p"] = byte_decode(
-                fields=pkt[282:286]) / 100
+            han_data["reactive_energy_p"] = byte_decode(fields=pkt[282:286]) / 100
             sensor_data["ams_reactive_energy_import"] = {
-                'state': han_data["reactive_energy_p"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_r_e_p"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["reactive_energy_p"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_r_e_p"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
             }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[288:294])
-            han_data["reactive_energy_n"] = byte_decode(
-                fields=pkt[295:299]) / 100
+            han_data["reactive_energy_n"] = byte_decode(fields=pkt[295:299]) / 100
             sensor_data["ams_reactive_energy_export"] = {
-                'state': han_data["reactive_energy_n"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_r_e_n"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                }
+                "state": han_data["reactive_energy_n"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_r_e_n"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
             }
 
-    if (list_type is LIST_TYPE_SHORT_1PH or
-            list_type is LIST_TYPE_LONG_1PH):
+    if list_type is LIST_TYPE_SHORT_1PH or list_type is LIST_TYPE_LONG_1PH:
 
         han_data["obis_v_l1"] = field_type(".", fields=pkt[168:174])
         han_data["voltage_l1"] = byte_decode(fields=pkt[175:177], count=2)
         sensor_data["ams_voltage_l1"] = {
-            'state': han_data["voltage_l1"],
-            'attributes': {
-                'timestamp': han_data["date_time"],
-                'meter_manufacturer': han_data["obis_list_version"].title(),
-                'meter_type': han_data["meter_type_str"],
-                'meter_serial': han_data["meter_serial"],
-                'obis_code': han_data["obis_v_l1"],
-                'unit_of_measurement': 'V',
-                'icon': 'mdi:flash'
-                }
-            }
+            "state": han_data["voltage_l1"],
+            "attributes": {
+                "timestamp": han_data["date_time"],
+                "meter_manufacturer": han_data["obis_list_version"].title(),
+                "meter_type": han_data["meter_type_str"],
+                "meter_serial": han_data["meter_serial"],
+                "obis_code": han_data["obis_v_l1"],
+                "unit_of_measurement": "V",
+                "icon": "mdi:flash",
+            },
+        }
 
         if list_type == LIST_TYPE_LONG_1PH:
-            han_data["obis_meter_date_time"] = field_type(
-                ".", fields=pkt[179:185])
+            han_data["obis_meter_date_time"] = field_type(".", fields=pkt[179:185])
             meter_date_time_year = byte_decode(fields=pkt[187:189], count=2)
             meter_date_time_month = pkt[189]
             meter_date_time_date = pkt[190]
@@ -315,80 +318,79 @@ def parse_data(stored, data):
             meter_date_time_hour = str(pkt[192]).zfill(2)
             meter_date_time_minute = str(pkt[193]).zfill(2)
             meter_date_time_seconds = str(pkt[194]).zfill(2)
-            han_data["meter_date_time"] = (str(meter_date_time_year) +
-                                           '-' + str(meter_date_time_month) +
-                                           '-' + str(meter_date_time_date) +
-                                           ' ' + meter_date_time_hour +
-                                           ':' + meter_date_time_minute +
-                                           ':' + meter_date_time_seconds)
+            han_data["meter_date_time"] = (
+                str(meter_date_time_year)
+                + "-"
+                + str(meter_date_time_month)
+                + "-"
+                + str(meter_date_time_date)
+                + " "
+                + meter_date_time_hour
+                + ":"
+                + meter_date_time_minute
+                + ":"
+                + meter_date_time_seconds
+            )
             han_data["obis_a_e_p"] = field_type(".", fields=pkt[201:207])
-            han_data["active_energy_p"] = byte_decode(
-                fields=pkt[208:212]) / 100
+            han_data["active_energy_p"] = byte_decode(fields=pkt[208:212]) / 100
             sensor_data["ams_active_energy_import"] = {
-                'state': han_data["active_energy_p"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_p"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["active_energy_p"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_p"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
+            }
             han_data["obis_a_e_n"] = field_type(".", fields=pkt[214:220])
-            han_data["active_energy_n"] = byte_decode(
-                fields=pkt[221:225]) / 100
+            han_data["active_energy_n"] = byte_decode(fields=pkt[221:225]) / 100
             sensor_data["ams_active_energy_export"] = {
-                'state': han_data["active_energy_n"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_a_e_n"],
-                    'unit_of_measurement': 'kWh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["active_energy_n"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_a_e_n"],
+                    "unit_of_measurement": "kWh",
+                    "icon": "mdi:gauge",
+                },
+            }
             han_data["obis_r_e_p"] = field_type(".", fields=pkt[227:233])
-            han_data["reactive_energy_p"] = byte_decode(
-                fields=pkt[234:238]) / 100
+            han_data["reactive_energy_p"] = byte_decode(fields=pkt[234:238]) / 100
             sensor_data["ams_reactive_energy_import"] = {
-                'state': han_data["reactive_energy_p"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_r_e_p"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["reactive_energy_p"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_r_e_p"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
+            }
             han_data["obis_r_e_n"] = field_type(".", fields=pkt[240:246])
-            han_data["reactive_energy_n"] = byte_decode(
-                fields=pkt[247:251]) / 100
+            han_data["reactive_energy_n"] = byte_decode(fields=pkt[247:251]) / 100
             sensor_data["ams_reactive_energy_export"] = {
-                'state': han_data["reactive_energy_n"],
-                'attributes': {
-                    'timestamp': han_data["date_time"],
-                    'meter_timestamp': han_data["meter_date_time"],
-                    'meter_manufacturer':
-                        han_data["obis_list_version"].title(),
-                    'meter_type': han_data["meter_type_str"],
-                    'meter_serial': han_data["meter_serial"],
-                    'obis_code': han_data["obis_r_e_n"],
-                    'unit_of_measurement': 'kVArh',
-                    'icon': 'mdi:gauge'
-                    }
-                }
+                "state": han_data["reactive_energy_n"],
+                "attributes": {
+                    "timestamp": han_data["date_time"],
+                    "meter_timestamp": han_data["meter_date_time"],
+                    "meter_manufacturer": han_data["obis_list_version"].title(),
+                    "meter_type": han_data["meter_type_str"],
+                    "meter_serial": han_data["meter_serial"],
+                    "obis_code": han_data["obis_r_e_n"],
+                    "unit_of_measurement": "kVArh",
+                    "icon": "mdi:gauge",
+                },
+            }
 
     stored.update(sensor_data)
     return stored, han_data
@@ -401,32 +403,34 @@ def test_valid_data(data):
         return False
 
     if len(data) > 302 or len(data) < 180:
-        _LOGGER.debug('Invalid packet size %s', len(data))
+        _LOGGER.debug("Invalid packet size %s", len(data))
         return False
 
     if not data[0] and data[-1] == FRAME_FLAG:
-        _LOGGER.debug("%s Recieved %s bytes of %s data",
-                      datetime.now().isoformat(),
-                      len(data), False)
+        _LOGGER.debug(
+            "%s Recieved %s bytes of %s data",
+            datetime.now().isoformat(),
+            len(data),
+            False,
+        )
         return False
 
     header_checksum = CrcX25.calc(bytes(data[1:6]))
-    read_header_checksum = (data[7] << 8 | data[6])
+    read_header_checksum = data[7] << 8 | data[6]
 
     if header_checksum != read_header_checksum:
-        _LOGGER.debug('Invalid header CRC check')
+        _LOGGER.debug("Invalid header CRC check")
         return False
 
     frame_checksum = CrcX25.calc(bytes(data[1:-3]))
-    read_frame_checksum = (data[-2] << 8 | data[-3])
+    read_frame_checksum = data[-2] << 8 | data[-3]
 
     if frame_checksum != read_frame_checksum:
-        _LOGGER.debug('Invalid frame CRC check')
+        _LOGGER.debug("Invalid frame CRC check")
         return False
 
     if data[8:12] != DATA_FLAG:
-        _LOGGER.debug('Data does not start with %s: %s',
-                      DATA_FLAG, data[8:12])
+        _LOGGER.debug("Data does not start with %s: %s", DATA_FLAG, data[8:12])
         return False
 
     packet_size = len(data)
@@ -434,8 +438,10 @@ def test_valid_data(data):
 
     if packet_size != read_packet_size:
         _LOGGER.debug(
-            'Packet size does not match read packet size: %s : %s',
-            packet_size, read_packet_size)
+            "Packet size does not match read packet size: %s : %s",
+            packet_size,
+            read_packet_size,
+        )
         return False
 
     return True

--- a/custom_components/ams/sensor.py
+++ b/custom_components/ams/sensor.py
@@ -8,8 +8,14 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_utils
 
-from .const import (AMS_DEVICES, AMS_SENSOR_CREATED_BUT_NOT_READ, DOMAIN,
-                    HOURLY_SENSORS, SIGNAL_NEW_AMS_SENSOR, SIGNAL_UPDATE_AMS)
+from .const import (
+    AMS_DEVICES,
+    AMS_SENSOR_CREATED_BUT_NOT_READ,
+    DOMAIN,
+    HOURLY_SENSORS,
+    SIGNAL_NEW_AMS_SENSOR,
+    SIGNAL_UPDATE_AMS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
* Utilize `/dev/serial/by-id/SERIAL_DEVICE` to make comport persistent over host restarts.
* Black code formatting