### PR TITLE
Missing list_type comparison in aidon.py. Autodetect did not work for aidon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Kamstrup:
 
 Aidon:
  - 6525 Thanks to @razzymoose for testing and providing patch :+1:
+ - 6515 Thanks to @maxgyver87 for fault finding and testing :+1:
 
  Not tested with, but should work:
- - 6515
  - 6534
  - 6540
  - 6550

--- a/custom_components/ams/const.py
+++ b/custom_components/ams/const.py
@@ -2,7 +2,7 @@
 
 import serial
 
-AIDON_METER_SEQ = [65, 105, 100, 111, 110, 95]
+AIDON_METER_SEQ = [65, 73, 68, 79, 78, 95]
 AMS_NEW_SENSORS = "ams_new_sensors"
 AMS_SENSORS = "ams_sensors"
 # Devices that we have read from the serial connection.

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -147,7 +147,8 @@ def parse_data(stored, data):
         },
     }
 
-    if list_type is LIST_TYPE_SHORT_3PH_3W or LIST_TYPE_LONG_3PH_3W:
+    if (list_type is LIST_TYPE_SHORT_3PH_3W or
+            list_type is LIST_TYPE_LONG_3PH_3W):
 
         han_data["obis_c_l3"] = field_type(".", fields=pkt[194:200])
         han_data["current_l3"] = byte_decode(fields=pkt[201:203], count=2) / 10


### PR DESCRIPTION
There was a missing comparison argument in the aidon parser, making it decode the wrong list_type. This caused index errors.
Also autodetect did not work for Aidon.