### PR TITLE
Correct aidon 6534 packet size checker. Typo in parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Kamstrup:
 Aidon:
  - 6525 Thanks to @razzymoose for testing and providing patch :+1:
  - 6515 Thanks to @maxgyver87 for fault finding and testing :+1:
- - 6534 Thanks to mariwing for testing and debugging :+1:
+ - 6534 Thanks to @mariwing for testing and debugging :+1:
 
  Not tested with, but should work:
  - 6540

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Kamstrup:
 Aidon:
  - 6525 Thanks to @razzymoose for testing and providing patch :+1:
  - 6515 Thanks to @maxgyver87 for fault finding and testing :+1:
+ - 6534 Thanks to mariwing for testing and debugging :+1:
 
  Not tested with, but should work:
- - 6534
  - 6540
  - 6550
  

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -408,7 +408,7 @@ def parse_data(stored, data):
                     "icon": "mdi:gauge",
                 },
             }
-            han_data["obis_r_e_n"] = field_type(".", fields=pkt[376:3382])
+            han_data["obis_r_e_n"] = field_type(".", fields=pkt[376:382])
             han_data["reactive_energy_n"] = byte_decode(fields=pkt[383:387]) / 100
             sensor_data["ams_reactive_energy_export"] = {
                 "state": han_data["reactive_energy_n"],
@@ -526,7 +526,7 @@ def test_valid_data(data):
     if data is None:
         return False
 
-    if len(data) > 377 or len(data) < 44:
+    if len(data) > 397 or len(data) < 44:
         _LOGGER.debug("Invalid packet size %s", len(data))
         return False
 

--- a/custom_components/ams/parsers/aidon.py
+++ b/custom_components/ams/parsers/aidon.py
@@ -346,7 +346,7 @@ def parse_data(stored, data):
                 "icon": "mdi:flash",
             },
         }
-        if list_type is LIST_TYPE_LONG_3PH_3W:
+        if list_type is LIST_TYPE_LONG_3PH:
             meter_date_time_year = byte_decode(fields=pkt[297:299], count=2)
             meter_date_time_month = pkt[299]
             meter_date_time_date = pkt[300]


### PR DESCRIPTION
Wrong size comparison for big packets. (6534)
Typo in parser.(Packet position)
Wrong referenced list_type for comparison in 3phase 6534 meter.
Update README.md
Fixes #31 