### PR TITLE
Fix device_state_attributes warnings

### DIFF
--- a/custom_components/ams/sensor.py
+++ b/custom_components/ams/sensor.py
@@ -135,7 +135,7 @@ class AmsSensor(RestoreEntity):
         return False
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the attributes of the entity (if any JSON present)."""
         return self._attributes
 


### PR DESCRIPTION
Fixes these kind of warnings beginning in 2021.12.0:
Entity sensor.ams_active_power_import_*** (<class 'custom_components.ams.sensor.AmsSensor'>) implements device_state_attributes. Please report it to the custom component author.