### PR TITLE
Fix for frame sync issues.

### DIFF
--- a/custom_components/ams/__init__.py
+++ b/custom_components/ams/__init__.py
@@ -177,7 +177,11 @@ class AmsHub:
                             frame_started = 0
                             packet_size = -1
             else:
-                continue
+                if frame_started:
+                    _LOGGER.debug("Timeout waiting for end of packet. Flush current packet.")
+                    frame_started = False
+                    byte_counter = 0
+                    bytelist = []
 
     @property
     def meter_serial(self):


### PR DESCRIPTION
When missing the start of the frame, the logic gets out of sync and will never recover.
This fix utilizes the fact that packets are sent two seconds apart. If we timeout, the
next byte will most likely be the start of a new packet.