### PR TITLE
fixes crashes if kaifa is not autodetected

### DIFF
--- a/custom_components/ams/__init__.py
+++ b/custom_components/ams/__init__.py
@@ -267,7 +267,7 @@ class AmsHub:
         elif self.meter_manufacturer == "aidon_se":
             parser = Aidon_se
         elif self.meter_manufacturer == "kaifa":
-            if field_type(fields=detect_pkg[62:70], enc=chr) == "MA304H4D":
+            if detect_pkg and field_type(fields=detect_pkg[62:70], enc=chr) == "MA304H4D":
                 swedish = True
                 parser = Kaifa
             else:

--- a/custom_components/ams/parsers/kaifa.py
+++ b/custom_components/ams/parsers/kaifa.py
@@ -40,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=too-many-locals, too-many-statements
-def parse_data(stored, data, swedish):
+def parse_data(stored, data, swedish = False):
     """Parse the incoming data to dict."""
     sensor_data = {}
     han_data = {}


### PR DESCRIPTION
Fixes two crashes:

`__init__.py` line 270: `detect_pkg` is None if `self.meter_manufacturer` is not set to `auto`

`kaifa.py` line 43: in the case of Norwegian kaifa, `parse_data` is called without the required 3rd positional argument (`__init__.py` line 294)