### PR TITLE
Fix broken init with HA 2025.6.0 due to using deprecated function.

### DIFF
--- a/custom_components/ams/__init__.py
+++ b/custom_components/ams/__init__.py
@@ -9,6 +9,7 @@ import serial
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
+from homeassistant.const import Platform
 from homeassistant.core import Config, HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from custom_components.ams.parsers import aidon as Aidon
@@ -49,6 +50,8 @@ from custom_components.ams.const import (
     SIGNAL_NEW_AMS_SENSOR,
     SIGNAL_UPDATE_AMS,
 )
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,13 +114,13 @@ async def async_setup(hass: HomeAssistant, config: Config):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up AMS as config entry."""
     _setup(hass, entry.data)
-    await hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
This fixes the currently broken init, only some minor changes were needed.

If you are a user, these changes can be manually applied by editing `ha-config/custom_components/ams/__init__.py` and then restarting Home Assistant.

PS: hass-AMS will break again in November due to another deprecation:
` WARNING (ImportExecutor_0) [homeassistant.core] Config was used from ams, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead, please report it to the author of the 'ams' custom integration`

Fixes #109 