### PR TITLE
github action fixup

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.13','3.14']
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ['3.13','3.14']
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Saw that the action failed to run because it was using a too old python version that pulled hass packages that had older api, so changed it to a version that is supported.
With that changed all test passes

I also took the liberty to upgrade the checkout and python-setup actions to the latest versions